### PR TITLE
update cypress docker image

### DIFF
--- a/examples/audit/gitlab-ci.yml
+++ b/examples/audit/gitlab-ci.yml
@@ -12,7 +12,7 @@
 
 test_example_audit_app:
   extends: .example_audit_base
-  image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+  image: cypress/browsers:node16.18.0-chrome107-ff106-edge
   stage: Integration Test
   script:
     - npm run cypress:ci

--- a/examples/audit/package.json
+++ b/examples/audit/package.json
@@ -27,7 +27,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "cypress:ci": "start-server-and-test \"npm run start:ci\" http://localhost:8080 \"npm run cypress:run\"",
-    "cypress:run": "cypress run --browser chrome",
+    "cypress:run": "cypress run",
     "cypress:open": "cypress open"
   },
   "eslintConfig": {


### PR DESCRIPTION
Testing to see if this resolves the broken CI/CD error:
```
[506:1122/232411.367442:ERROR:gpu_memory_buffer_support_x11.cc(44)] dri3 extension not supported.
```
