### PR TITLE
GEA-3432: set error during login flow when token check status is not successful

### DIFF
--- a/packages/react-auth/src/AuthProvider/index.tsx
+++ b/packages/react-auth/src/AuthProvider/index.tsx
@@ -181,7 +181,18 @@ export const AuthProvider: FC<AuthProviderProps> = ({
     axios
       .post(checkURL, { token }, { headers: clientHeaders() })
       .then((resp) => {
-        setAuthenticated(true);
+        /**
+         * Only set authenticated to true if we return a successful status
+         *
+         * It's entirely possible to get a status back: "InvalidToken"
+         * when that happens we want to throw an error and stop
+         * the login flow
+         */
+        if (resp.data.status === "Success") {
+          setAuthenticated(true);
+        } else {
+          throw resp.data?.status;
+        }
       })
       .catch((error) => {
         let msg = "Token validation error";


### PR DESCRIPTION
This doesn't include code for removing the `state` and `code` URL search parameters during the login flow.

I ran into more issues removing it from the AuthProvider side instead of the application side. Biggest issue being an extra page refresh from calling `window.location.replace` within `processLogin`