### PR TITLE
Rename /lookup endpoint to /reputation

### DIFF
--- a/examples/intel/ip.mjs
+++ b/examples/intel/ip.mjs
@@ -12,7 +12,7 @@ const ipIntel = new IPIntelService(String(token), config);
 
   const options = { provider: "domaintools", verbose: true, raw: true };
   try {
-    const response = await ipIntel.lookup("93.231.182.110", options);
+    const response = await ipIntel.reputation("93.231.182.110", options);
     console.log(response.result);
   } catch (e) {
     if (e instanceof PangeaErrors.APIError) {

--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Intel IP add reputation endpoint that will replace lookup endpoint
+
 ## [1.1.1] - 2023-01-05
 
 ### Fixed

--- a/packages/pangea-node-sdk/src/services/intel.ts
+++ b/packages/pangea-node-sdk/src/services/intel.ts
@@ -197,7 +197,7 @@ export class IPIntelService extends BaseService {
    *   Default provider defined by the configuration.
    *   - verbose {Boolean} - Echo the API parameters in the response. Default: verbose=false.
    *   - raw {Boolean} - Include raw data from this provider. Default: raw=false.
-   * @returns {Promise} - A promise representing an async call to the lookup endpoint.
+   * @returns {Promise} - A promise representing an async call to the /reputation endpoint.
    * @example
    * const options = {
    *   provider: "reversinglabs"
@@ -229,7 +229,7 @@ export class IPIntelService extends BaseService {
    *   Default provider defined by the configuration.
    *   - verbose {Boolean} - Echo the API parameters in the response. Default: verbose=false.
    *   - raw {Boolean} - Include raw data from this provider. Default: raw=false.
-   * @returns {Promise} - A promise representing an async call to the lookup endpoint.
+   * @returns {Promise} - A promise representing an async call to the /reputation endpoint.
    * @example
    * const options = {
    *   provider: "reversinglabs"

--- a/packages/pangea-node-sdk/src/services/intel.ts
+++ b/packages/pangea-node-sdk/src/services/intel.ts
@@ -190,6 +190,7 @@ export class IPIntelService extends BaseService {
   /**
    * @summary Look up an IP
    * @description Retrieve a reputation score for an IP address from a provider, including an optional detailed report.
+   * @deprecated Since version 1.2.0. Use reputation instead.
    * @param {String} ip - Geolocate this IP and check the corresponding country against
    * @param {Object} options - An object of optional parameters. Parameters supported:
    *   - provider {String} - Use reputation data from this provider: "crowdstrike".
@@ -216,7 +217,39 @@ export class IPIntelService extends BaseService {
     if (options?.verbose) data.verbose = options.verbose;
     if (options?.raw) data.raw = options.raw;
 
-    return this.post("lookup", data);
+    return this.post("reputation", data);
+  }
+
+  /**
+   * @summary Look up an IP reputation
+   * @description Retrieve a reputation score for an IP address from a provider, including an optional detailed report.
+   * @param {String} ip - Geolocate this IP and check the corresponding country against
+   * @param {Object} options - An object of optional parameters. Parameters supported:
+   *   - provider {String} - Use reputation data from this provider: "crowdstrike".
+   *   Default provider defined by the configuration.
+   *   - verbose {Boolean} - Echo the API parameters in the response. Default: verbose=false.
+   *   - raw {Boolean} - Include raw data from this provider. Default: raw=false.
+   * @returns {Promise} - A promise representing an async call to the lookup endpoint.
+   * @example
+   * const options = {
+   *   provider: "reversinglabs"
+   * };
+   *
+   * const response = await ipIntel.reputation(
+   *   "1.1.1.1",
+   *   options
+   * );
+   */
+  reputation(ip: string, options?: Intel.Options): Promise<PangeaResponse<Intel.Response>> {
+    const data: Intel.IPParams = {
+      ip,
+    };
+
+    if (options?.provider) data.provider = options.provider;
+    if (options?.verbose) data.verbose = options.verbose;
+    if (options?.raw) data.raw = options.raw;
+
+    return this.post("reputation", data);
   }
 }
 

--- a/packages/pangea-node-sdk/tests/integration/intel.test.ts
+++ b/packages/pangea-node-sdk/tests/integration/intel.test.ts
@@ -61,6 +61,15 @@ it("IP lookup should succeed", async () => {
   expect(response.result.data.verdict).toBe("malicious");
 });
 
+it("IP reputation should succeed", async () => {
+  const options = { provider: "crowdstrike", verbose: true, raw: true };
+  const response = await ipIntel.reputation("93.231.182.110", options);
+
+  expect(response.status).toBe("Success");
+  expect(response.result.data).toBeDefined();
+  expect(response.result.data.verdict).toBe("malicious");
+});
+
 it("URL lookup should succeed", async () => {
   const options = { provider: "crowdstrike", verbose: true, raw: true };
   const response = await urlIntel.lookup("http://113.235.101.11:54384", options);


### PR DESCRIPTION
- Mark /lookup as deprecated
- Implement /reputation
(Pending this changes to be merged on live backend)