### PR TITLE
GEA-9108

### DIFF
--- a/packages/pangea-node-sdk/package.json
+++ b/packages/pangea-node-sdk/package.json
@@ -1,11 +1,12 @@
 {
   "name": "pangea-node-sdk",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "module",
   "exports": {
     "types": "./dist/index.d.ts",
     "default": "./dist/index.js"
   },
+  "types": "./dist/index.d.ts",
   "repository": "git@github.com:pangeacyber/pangea-javascript.git",
   "author": "Glenn Gallien <glenn.gallien@pangea.cloud>",
   "license": "MIT",

--- a/packages/pangea-node-sdk/src/config.ts
+++ b/packages/pangea-node-sdk/src/config.ts
@@ -1,6 +1,6 @@
 import { ConfigOptions, ConfigEnv } from "./types.js";
 
-export const version = "2.2.0";
+export const version = "2.2.1";
 
 class PangeaConfig {
   domain: string = "pangea.cloud";


### PR DESCRIPTION
Default nextjs create app has a tsconfig with `moduleResolution: "node"`, using Node10, so it doesn't check exports from package.json.

A couple people in builders have run into types not resolving, I did notice changing module and moduleResolution to node16 or nodenext does fix the types issue, but I'm also thinking why not just have the types declaration in our package.json so that even `moduleResoltion: "node"` will still be able to find the types