### PR TITLE
pangea-node-sdk: update crypto-js in lockfile (GEA-11240) 

### DIFF
--- a/packages/pangea-node-sdk/.gitlab-ci.yml
+++ b/packages/pangea-node-sdk/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 .pangea_node_sdk_base:
   before_script:
     - cd packages/pangea-node-sdk
-    - yarn install
+    - yarn install --frozen-lockfile
   cache:
     - key:
         files:
@@ -17,7 +17,7 @@
 .pangea_node_sdk_publish:
   before_script:
     - cd packages/pangea-node-sdk
-    - yarn install
+    - yarn install --frozen-lockfile
     - apt-get -qq update
     - apt-get install -y jq
   cache:

--- a/packages/pangea-node-sdk/yarn.lock
+++ b/packages/pangea-node-sdk/yarn.lock
@@ -1519,10 +1519,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
-  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 cssesc@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
In e54e6876fef2d2ccff8f660f216cec3d2d72befa we updated crypto-js but did not update the lockfile.