### PR TITLE
Fix SDK publishing (GEA-11855)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 default:
-  image: node
+  image: node:18.19.0
   tags:
     - pangea-internal
 
@@ -12,7 +12,6 @@ stages:
   - Test Public
 
 .packages_base:
-  image: node
   before_script:
     - yarn install
   cache:

--- a/packages/pangea-node-sdk/.gitlab-ci.yml
+++ b/packages/pangea-node-sdk/.gitlab-ci.yml
@@ -18,8 +18,8 @@
   before_script:
     - cd packages/pangea-node-sdk
     - yarn install --frozen-lockfile
-    - apt-get -qq update
-    - apt-get install -y jq
+    - apt update -y
+    - apt install -y jq
   cache:
     - key:
         files:
@@ -73,9 +73,7 @@ tag_pangea_node_sdk:
   extends: .pangea_node_sdk_publish
   stage: Tag Release
   script:
-    - apt-get install python3 -y
-    - apt-get install python3-pip -y
-    - apt-get install pygithub -y
+    - apt install -y python3 python3-github
     - VERSION=$(node -p "require('./package.json').version")
     - cp ../../scripts/tag_release.py .
     - python3 tag_release.py ${GITHUB_TOKEN} ${VERSION} ${CI_COMMIT_SHA} "pangea-node-sdk" "Pangea Node SDK"

--- a/packages/react-auth/.gitlab-ci.yml
+++ b/packages/react-auth/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 .react_auth_base:
-  image: node
+  image: node:18.19.0
   before_script:
     - cd packages/react-auth
     - yarn install --frozen-lockfile
@@ -29,9 +29,7 @@ tag_react_auth:
   extends: .react_auth_base
   stage: Tag Release
   script:
-    - apt-get install python3 -y
-    - apt-get install python3-pip -y
-    - pip3 install PyGithub
+    - apt install -y python3 python3-github
     - VERSION=$(node -p "require('./package.json').version")
     - cp ../../scripts/tag_release.py .
     - python3 tag_release.py ${GITHUB_TOKEN} ${VERSION} ${CI_COMMIT_SHA} "react-auth" "React Auth"

--- a/packages/react-mui-audit-log-viewer/.gitlab-ci.yml
+++ b/packages/react-mui-audit-log-viewer/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 .react_mui_audit_log_viewer_base:
-  image: node
+  image: node:18.19.0
   before_script:
     - cd packages/react-mui-audit-log-viewer
     - yarn install

--- a/packages/react-mui-authn/.gitlab-ci.yml
+++ b/packages/react-mui-authn/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 .react_mui_authn_base:
-  image: node
+  image: node:18.19.0
   before_script:
     - cd packages/react-mui-authn
     - yarn install --frozen-lockfile
@@ -29,9 +29,7 @@ tag_react_auth:
   extends: .react_mui_authn_base
   stage: Tag Release
   script:
-    - apt-get install python3 -y
-    - apt-get install python3-pip -y
-    - apt-get install pygithub -y
+    - apt install -y python3 python3-github
     - VERSION=$(node -p "require('./package.json').version")
     - cp ../../scripts/tag_release.py .
     - python3 tag_release.py ${GITHUB_TOKEN} ${VERSION} ${CI_COMMIT_SHA} "react-mui-authn" "React MUI AuthN"

--- a/packages/react-mui-branding/.gitlab-ci.yml
+++ b/packages/react-mui-branding/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 .react_mui_branding_base:
-  image: node
+  image: node:18.19.0
   before_script:
     - cd packages/react-mui-branding
     - yarn install

--- a/packages/react-mui-shared/.gitlab-ci.yml
+++ b/packages/react-mui-shared/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 .react_mui_shared_base:
-  image: node
+  image: node:18.19.0
   before_script:
     - cd packages/react-mui-shared
     - yarn install

--- a/packages/react-mui-store-file-viewer/.gitlab-ci.yml
+++ b/packages/react-mui-store-file-viewer/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 .react_mui_store_file_viewer_base:
-  image: node
+  image: node:18.19.0
   before_script:
     - cd packages/react-mui-store-file-viewer
     - yarn install

--- a/packages/vanilla-js/.gitlab-ci.yml
+++ b/packages/vanilla-js/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 .vanilla_js_base:
-  image: node
+  image: node:18.19.0
   before_script:
     - cd packages/vanilla-js
     - yarn install

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 PACKAGE_NAME=$(jq .name package.json | tr -d '"')
 echo "Looking to update: $PACKAGE_NAME"
 if [ $PACKAGE_NAME = "" ] ; then
@@ -13,7 +14,7 @@ echo "Published packaged version $LATEST_PACKAGE_VERSION"
 
 if [ "$PACKAGE_VERSION" != "$LATEST_PACKAGE_VERSION" ] ; then
     yarn build
-	yarn publish --new-version $PACKAGE_VERSION
+	  yarn publish --new-version $PACKAGE_VERSION
 else
-    echo "Package not updated. Skipping publish" 
+    echo "Package not updated. Skipping publish"
 fi

--- a/scripts/tag_release.py
+++ b/scripts/tag_release.py
@@ -1,7 +1,7 @@
 import argparse
-import sys
 
 from github import Github
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Tag a release in GitHub")
@@ -12,6 +12,7 @@ def parse_args():
     parser.add_argument("tag_name", help="Tag Name")
     args = parser.parse_args()
     return args
+
 
 def main():
     args = parse_args()
@@ -27,7 +28,6 @@ def main():
 
     print(f"Tag version: {tag}")
     if args.version.find('beta'):
-        
         repo.create_git_tag(
             tag,
             tag_message,
@@ -44,7 +44,7 @@ def main():
             object,
             type
         )
-    
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/validate_latest_installed.sh
+++ b/scripts/validate_latest_installed.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
 PACKAGE_NAME="$1"
 
 PACKAGE_VERSION=$(npm list --depth=0 --json | jq .dependencies.$PACKAGE_NAME.version | tr -d '"')
@@ -11,5 +12,5 @@ if [ "$PACKAGE_VERSION" != "$LATEST_PACKAGE_VERSION" ] ; then
     echo "Package installed for $PACKAGE_NAME ($PACKAGE_VERSION) does not match latest package $LATEST_PACKAGE_VERSION"
     exit 1
 else
-    echo "Package not updated. Skipping publish" 
+    echo "Package not updated. Skipping publish"
 fi


### PR DESCRIPTION
The apt package is named "python3-github", not "pygithub". <https://packages.debian.org/bookworm/python3-github>

Removed the installation of pip since we were not actually using it. In reality we _should_ be installing Python packages with pip, not apt, but I don't want to change too much here yet.

Also pinned the Node.js image version to make things more deterministic.