### PR TITLE
fixed bug in parsing presigned url response in example

### DIFF
--- a/examples/file_scan/file_scan_request_upload_url_put.mjs
+++ b/examples/file_scan/file_scan_request_upload_url_put.mjs
@@ -45,7 +45,7 @@ const delay = async (ms) =>
     response = await client.requestUploadURL(request);
 
     // extract upload url that should be posted with the file
-    const url = response.accepted_result?.accepted_status.upload_url || "";
+    const url = response.accepted_result?.put_url || "";
     console.log(`Got presigned url: ${url}`);
 
     // Create an uploader and upload the file


### PR DESCRIPTION
Fixed bug in pre signed `put-url` file scan example

The example was using `response.accepted_result?.accepted_status.upload_url` to parse the pre-signed URL while it should have been `response.accepted_result?.put_url`