### PR TITLE
pangea-node-sdk: replace node-rs/crc32 (GEA-11594)

### DIFF
--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rewrote `README.md`.
+- The dependency on node-rs/crc32 has been replaced by one on aws-crypto/crc32c,
+  a pure-JS implementation of CRC32C.
 
 ## [3.6.0] - 2024-01-12
 

--- a/packages/pangea-node-sdk/package.json
+++ b/packages/pangea-node-sdk/package.json
@@ -14,7 +14,7 @@
     "node": "18 || >=20"
   },
   "dependencies": {
-    "@node-rs/crc32": "^1.7.2",
+    "@aws-crypto/crc32c": "^5.2.0",
     "crypto-js": "^4.2.0",
     "form-data": "^4.0.0",
     "got": "^13.0.0",

--- a/packages/pangea-node-sdk/src/utils/utils.ts
+++ b/packages/pangea-node-sdk/src/utils/utils.ts
@@ -1,9 +1,12 @@
+import { Buffer } from "node:buffer";
+import crypto from "node:crypto";
+import fs from "node:fs";
+
+import { crc32c } from "@aws-crypto/crc32c";
 import CryptoJS from "crypto-js";
-import * as crypto from "crypto";
-import * as fs from "fs";
-import crc32c from "@node-rs/crc32";
-import { FileScan } from "@src/types.js";
+
 import { PangeaErrors } from "@src/errors.js";
+import { FileScan } from "@src/types.js";
 
 function orderKeysRecursive(obj: Object) {
   const orderedEntries = Object.entries(obj).sort((a, b) => a[0].localeCompare(b[0]));
@@ -141,7 +144,7 @@ export function getFileUploadParams(file: string | Buffer): FileScan.ScanFilePar
   let data: Buffer;
   if (typeof file === "string") {
     data = fs.readFileSync(file);
-  } else if (file instanceof Buffer) {
+  } else if (Buffer.isBuffer(file)) {
     data = file;
   } else {
     throw new PangeaErrors.PangeaError("Invalid file type");
@@ -149,9 +152,8 @@ export function getFileUploadParams(file: string | Buffer): FileScan.ScanFilePar
 
   const size = data.length;
   hash.update(data);
-  const crcValue = crc32c.crc32c(data);
   const sha256hex = hash.digest("hex");
-
+  const crcValue = crc32c(data);
   return {
     sha256: sha256hex,
     crc32c: crcValue.toString(16),

--- a/packages/pangea-node-sdk/tests/unit/utils.test.ts
+++ b/packages/pangea-node-sdk/tests/unit/utils.test.ts
@@ -1,26 +1,27 @@
+import fs from "node:fs/promises";
+
 import { it, expect } from "@jest/globals";
-import crc32c from "@node-rs/crc32";
-import * as fs from "fs";
+
 import { hashSHA1, hashSHA256, getHashPrefix, strToB64, b64toStr, hashNTLM } from "@src/index.js";
 import { getFileUploadParams } from "@src/utils/utils.js";
 
 const testfilePath = "./tests/testdata/testfile.pdf";
 
-it("Hash functions", async () => {
+it("Hash functions", () => {
   const msg = "texttohash";
 
   expect(hashSHA256(msg)).toBe("d80cb0aae262f2b06bacc163f483fae428b8b282471b9c8e337e40992dd65c2c");
   expect(hashSHA1(msg)).toBe("53d7223d32f18504cd22de99647a6b5eab0c530c");
 });
 
-it("Hash prefix", async () => {
+it("Hash prefix", () => {
   const hash = "123456789";
 
   expect(getHashPrefix(hash)).toBe("12345");
   expect(getHashPrefix(hash, 3)).toBe("123");
 });
 
-it("Base 64 strings", async () => {
+it("Base 64 strings", () => {
   const msg = "texttoconvert";
   const msgB64 = strToB64(msg);
   const msgRecovered = b64toStr(msgB64);
@@ -28,20 +29,13 @@ it("Base 64 strings", async () => {
   expect(msgRecovered).toBe(msg);
 });
 
-it("hashNTLM test", async () => {
+it("hashNTLM test", () => {
   const msg = "password";
   const hash = hashNTLM(msg);
   expect(hash).toBe("8846F7EAEE8FB117AD06BDD830B7586C");
 });
 
-it("CRC32C test", async () => {
-  const msg = "ABCDEF";
-  let crcValue = crc32c.crc32c(msg, 0) >>> 0;
-  const crc = crcValue.toString(16);
-  expect(crc).toBe("a4b7ce68");
-});
-
-it("getFileParams test filepath", async () => {
+it("getFileParams test filepath", () => {
   const paramsFilepath = getFileUploadParams(testfilePath);
   expect(paramsFilepath.crc32c).toBe("754995fb");
   expect(paramsFilepath.sha256).toBe(
@@ -51,7 +45,7 @@ it("getFileParams test filepath", async () => {
 });
 
 it("getFileParams test buffer", async () => {
-  const file = fs.readFileSync(testfilePath);
+  const file = await fs.readFile(testfilePath);
   const paramsFilepath = getFileUploadParams(file);
 
   expect(paramsFilepath.crc32c).toBe("754995fb");

--- a/packages/pangea-node-sdk/yarn.lock
+++ b/packages/pangea-node-sdk/yarn.lock
@@ -15,6 +15,32 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aws-crypto/crc32c@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz#4e34aab7f419307821509a98b9b08e84e0c1917e"
+  integrity sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==
+  dependencies:
+    "@aws-crypto/util" "^5.2.0"
+    "@aws-sdk/types" "^3.222.0"
+    tslib "^2.6.2"
+
+"@aws-crypto/util@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/util/-/util-5.2.0.tgz#71284c9cffe7927ddadac793c14f14886d3876da"
+  integrity sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==
+  dependencies:
+    "@aws-sdk/types" "^3.222.0"
+    "@smithy/util-utf8" "^2.0.0"
+    tslib "^2.6.2"
+
+"@aws-sdk/types@^3.222.0":
+  version "3.502.0"
+  resolved "https://registry.yarnpkg.com/@aws-sdk/types/-/types-3.502.0.tgz#c23dda4df7fdbe32642d4f5ab23516f455fb6aba"
+  integrity sha512-M0DSPYe/gXhwD2QHgoukaZv5oDxhW3FfvYIrJptyqUq3OnPJBcDbihHjrE0PBtfh/9kgMZT60/fQ2NVFANfa2g==
+  dependencies:
+    "@smithy/types" "^2.9.1"
+    tslib "^2.5.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.22.5.tgz#234d98e1551960604f1246e6475891a570ad5658"
@@ -627,90 +653,6 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@node-rs/crc32-android-arm-eabi@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.7.2.tgz#a52426050c90d3062b6ba0c980cd70a59ad9448d"
-  integrity sha512-6IoXQTHt9U/1Ejz/MPbAk3mtcAGcS1WUvg2YfEtezLCmzbDpQO3OTA9fZpu3z2AhBuLHiKMKDVcfrWybRiWBJw==
-
-"@node-rs/crc32-android-arm64@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.7.2.tgz#40bbbb54289fe47abf67558d22d87abace78d7d3"
-  integrity sha512-SMEd6cN+034LTv9kFmCGMZjBNTf39xXIcgqq05JM9A55ywUvXdoXnFOttrQ9x/iZgqANNU6Ms5uZCAJbNA2dZA==
-
-"@node-rs/crc32-darwin-arm64@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.7.2.tgz#3fa11b1176a1d463accf95deb046896487e0d374"
-  integrity sha512-sPJisK5pyZ+iBs9KuGsvu0Z+Qshw4GvOgaHjPktQ+suz0p00Yts3zl5D6PpGaaW4EAKTo8zCUIlVEArV0vglvw==
-
-"@node-rs/crc32-darwin-x64@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.7.2.tgz#bf5b1b3e471da1c84e5af19c8a4f667cb0e31540"
-  integrity sha512-+/lgHYJaZdXU+7fhGYTnXvGkeSqZE3UwPyKAUO5YSL0nIpFHMybZMnvqjcoxrfx0QfMFOwVEbd7vfVh+1GpwhA==
-
-"@node-rs/crc32-freebsd-x64@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.7.2.tgz#25ae223f69920141f81b5b611f763be6cc9ece42"
-  integrity sha512-OgkxnkiGdztcBilm7m31Sb6zx89ghK4WpZz9WVVU86PIHQH0sfrZEebdomw6R7mMnQuqbnRwjTS5r1nchVMPzQ==
-
-"@node-rs/crc32-linux-arm-gnueabihf@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.7.2.tgz#b26c60564a85cd92de5961050aaa9b5e62dda97c"
-  integrity sha512-hTY83MQML8WrMnD3dmzjrcCn0Sqgw0w2wRc1Ji2dCaE0fDqra47W5KBQXx4hKZYFwNr5KreTqdvD3Ejf/mKzEA==
-
-"@node-rs/crc32-linux-arm64-gnu@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.7.2.tgz#076e43f3592496a1cbea69e0e8fb3031d7711569"
-  integrity sha512-4p6DZ9YT+CBSi+72OclzI5hBin15brqrbLLHFePPl4AhAazg6+ReTv3C4DnyJqyL0ZHZamiA9zDtOlvHo0nk0Q==
-
-"@node-rs/crc32-linux-arm64-musl@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.7.2.tgz#e0e6860aee2364bb7289b4966406820794a921c6"
-  integrity sha512-/shZkkNyDyDjaxU5rYFY4aoajLjBqdfKQYZCcA6XS27FiGzHQ3petgP0I5Zjm+Jf75G7gLT8NQXiQWIzkgo2xw==
-
-"@node-rs/crc32-linux-x64-gnu@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.7.2.tgz#f17f2d570823ae9195296960af2045d9f76108eb"
-  integrity sha512-rzoqXqPLjx5sx8jzEg/xRAdBDkjnaM+D3Nrm9xJckHWzeeUB0FC0E4QGrdtqFo15lQ1GDVV/q6n93mLSK5vCkQ==
-
-"@node-rs/crc32-linux-x64-musl@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.7.2.tgz#3a3406486db63ffcdb6e4c08681d91dba8585640"
-  integrity sha512-Hwim1Wc8LoNqG53qX8Dm3VY32ClbKWpdi9pkbJU4/aG5RFUfd3k/x9WSeATlBx+K36Tc1XsrWvbsf1eWwryEYA==
-
-"@node-rs/crc32-win32-arm64-msvc@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.7.2.tgz#501cc0dfe7e0f9eb3af2ec1432f5f3bfa3d3ee6b"
-  integrity sha512-vj+HWzwy86wNBY+1vW+QPje/MrJppufGCYIisFwvghBzk6WtClNGEjbQqotieIxDNohcmHREQEeg8wY8PMCvew==
-
-"@node-rs/crc32-win32-ia32-msvc@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.7.2.tgz#abc5e96fe941af5b736b82187ebb562d34646207"
-  integrity sha512-YQQtPkHvqbMEJmaMzEH3diYHk0q9zWb+Tkzij9d4OZZzpt4HM6j8FuiIB37BJ0CQmgMiDZEBYsX3KOfYxxO0VA==
-
-"@node-rs/crc32-win32-x64-msvc@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.7.2.tgz#7e509ea3969a0190324beb8c829f7845c547e4cf"
-  integrity sha512-DnluAFM6X8qsYVI1VaFQtI6ukigIQ2P4eVcEuNQ3d1lF5fs0RYAKY7Ajqrdk298TSGZ2joMiqfJksTHBsQoxtA==
-
-"@node-rs/crc32@^1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@node-rs/crc32/-/crc32-1.7.2.tgz#97070a68e6e40adb4414fbb881bb990b56e4527a"
-  integrity sha512-SmWxRftq+zYSv4qfhdFHM8ruBqY8eVTnIs43dFUWAyD0x6a7LpzNd8KHWqKxlaly8QGpGxBv2Dol/3gs5DeknA==
-  optionalDependencies:
-    "@node-rs/crc32-android-arm-eabi" "1.7.2"
-    "@node-rs/crc32-android-arm64" "1.7.2"
-    "@node-rs/crc32-darwin-arm64" "1.7.2"
-    "@node-rs/crc32-darwin-x64" "1.7.2"
-    "@node-rs/crc32-freebsd-x64" "1.7.2"
-    "@node-rs/crc32-linux-arm-gnueabihf" "1.7.2"
-    "@node-rs/crc32-linux-arm64-gnu" "1.7.2"
-    "@node-rs/crc32-linux-arm64-musl" "1.7.2"
-    "@node-rs/crc32-linux-x64-gnu" "1.7.2"
-    "@node-rs/crc32-linux-x64-musl" "1.7.2"
-    "@node-rs/crc32-win32-arm64-msvc" "1.7.2"
-    "@node-rs/crc32-win32-ia32-msvc" "1.7.2"
-    "@node-rs/crc32-win32-x64-msvc" "1.7.2"
-
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -760,6 +702,36 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
+
+"@smithy/is-array-buffer@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz#07b4c77ae67ed58a84400c76edd482271f9f957b"
+  integrity sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/types@^2.9.1":
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-2.9.1.tgz#ed04d4144eed3b8bd26d20fc85aae8d6e357ebb9"
+  integrity sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==
+  dependencies:
+    tslib "^2.5.0"
+
+"@smithy/util-buffer-from@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz#f9346bf8b23c5ba6f6bdb61dd9db779441ba8d08"
+  integrity sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==
+  dependencies:
+    "@smithy/is-array-buffer" "^2.1.1"
+    tslib "^2.5.0"
+
+"@smithy/util-utf8@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@smithy/util-utf8/-/util-utf8-2.1.1.tgz#690018dd28f47f014114497735e51417ea5900a6"
+  integrity sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==
+  dependencies:
+    "@smithy/util-buffer-from" "^2.1.1"
+    tslib "^2.5.0"
 
 "@szmarczak/http-timer@^5.0.1":
   version "5.0.1"
@@ -4590,7 +4562,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.6.2:
+tslib@^2.5.0, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
Replace node-rs/crc32 with a pure-JS implementation of CRC32C so that pangea-node-sdk can more easily be added to Next.js projects without requiring the addition of a native addon loader like node-loader.

Verified working locally on @snpranav's Next.js App Router test app.