### PR TITLE
pangea-node-sdk: fix CI not caching dependencies (GEA-12312)

### DIFF
--- a/packages/pangea-node-sdk/.gitlab-ci.yml
+++ b/packages/pangea-node-sdk/.gitlab-ci.yml
@@ -5,9 +5,9 @@
   cache:
     - key:
         files:
-          - yarn.lock
+          - packages/pangea-node-sdk/yarn.lock
       paths:
-        - node_modules
+        - packages/pangea-node-sdk/node_modules
   rules:
     - if: $CI_COMMIT_BRANCH || $CI_PIPELINE_SOURCE == "push"
       changes:
@@ -53,9 +53,9 @@
   cache:
     - key:
         files:
-          - yarn.lock
+          - packages/pangea-node-sdk/yarn.lock
       paths:
-        - node_modules
+        - packages/pangea-node-sdk/node_modules
   parallel:
     matrix:
       - CLOUD: [AWS, GCP]
@@ -75,9 +75,9 @@
   cache:
     - key:
         files:
-          - yarn.lock
+          - packages/pangea-node-sdk/yarn.lock
       paths:
-        - node_modules
+        - packages/pangea-node-sdk/node_modules
   rules:
     - if: $CI_COMMIT_BRANCH == "release"
       changes:


### PR DESCRIPTION
The paths under `cache` need to be relative to the project's root directory. The paths defined in pangea-node-sdk's pipeline were written to be relative to pangea-node-sdk itself, but because they are read as relative to the project root nothing has been getting cached this whole time. This is clear from job logs:

    Saving cache for successful job 00:01
    Creating cache 0_yarn-e917e11da4cd6e873d1d40d7687bc1faf7f4e730-1-non_protected...
    WARNING: node_modules: no matching files. Ensure that the artifact path is relative to the working directory (/builds/pangeacyber/pangea-javascript)

This patch fixes this issue by updating the paths to be relative to the project's root directory.

Refer: <https://docs.gitlab.com/ee/ci/yaml/#cache>