### PR TITLE
Add `needs` back to examples pipeline (GEA-12320)

### DIFF
--- a/examples/.examples-ci.yml
+++ b/examples/.examples-ci.yml
@@ -1,5 +1,6 @@
 examples-tests:
   stage: examples
+  needs: [pangea-node-sdk-pack]
   parallel:
     matrix:
       - NODE_VERSION: [18, 20]


### PR DESCRIPTION
4375574 removed the examples pipeline's `needs` on `pack_pangea_node_sdk`, despite the pipeline actually depending on the artifact output of that job. This causes the pipeline to fail on `main`:

    $ pushd packages/pangea-node-sdk
    /builds/pangeacyber/pangea-javascript/packages/pangea-node-sdk /builds/pangeacyber/pangea-javascript
    $ tar -xf pangea-node-sdk-v*.tgz --strip-components 1 -C .
    tar: pangea-node-sdk-v*.tgz: Cannot open: No such file or directory
    tar: Error is not recoverable: exiting now

This patch adds back the `needs` to ensure that the required artifact is available.