### PR TITLE
Add ability to override theme options before creating theme

### DIFF
--- a/packages/react-mui-branding/package.json
+++ b/packages/react-mui-branding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pangeacyber/react-mui-branding",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Pangea wrapper around Material-UI branding theme provider",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
Before, adding any changes to the components field in themeOptions directly would override the entire components object erasing all branding styles. This made it impossible to add a shadow root target for popovers and modals.