### PR TITLE
pangea-node-sdk: pin typescript to v5.1.6 (GEA-12960)

### DIFF
--- a/packages/pangea-node-sdk/package.json
+++ b/packages/pangea-node-sdk/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@gitlab/eslint-plugin": "^19.4.0",
+    "@tsconfig/node18": "18.2.2",
     "@types/crypto-js": "^4.2.2",
     "@types/jest": "29.5.12",
     "@typescript-eslint/eslint-plugin": "^7.1.0",
@@ -38,7 +39,7 @@
     "ts-node": "^10.9.2",
     "tsc-alias": "^1.8.8",
     "typedoc": "^0.25.9",
-    "typescript": "^5.1.6"
+    "typescript": "5.1.6"
   },
   "scripts": {
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",

--- a/packages/pangea-node-sdk/tsconfig.json
+++ b/packages/pangea-node-sdk/tsconfig.json
@@ -1,12 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "module": "ES2020",
-    "moduleResolution": "nodenext",
     "moduleDetection": "force",
-    "target": "ES2020", // Node.js 14
     "esModuleInterop": true,
-    "lib": ["ES2020"],
     "allowSyntheticDefaultImports": true, // To provide backwards compatibility, Node.js allows you to import most CommonJS packages with a default import. This flag tells TypeScript that it's okay to use import on CommonJS modules.
     "resolveJsonModule": false, // ESM doesn't yet support JSON modules.
     "declaration": true,

--- a/packages/pangea-node-sdk/yarn.lock
+++ b/packages/pangea-node-sdk/yarn.lock
@@ -780,6 +780,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
+"@tsconfig/node18@18.2.2":
+  version "18.2.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node18/-/node18-18.2.2.tgz#81fb16ecff0d400b1cbadbf76713b50f331029ce"
+  integrity sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==
+
 "@types/babel__core@^7.1.14":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.1.tgz#916ecea274b0c776fec721e333e55762d3a9614b"
@@ -4669,7 +4674,7 @@ typedoc@^0.25.9:
     minimatch "^9.0.3"
     shiki "^0.14.7"
 
-typescript@^5.1.6:
+typescript@5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==


### PR DESCRIPTION
The current Jest setup doesn't work with anything newer.

Discovered in https://github.com/pangeacyber/pangea-javascript/pull/831.