### PR TITLE
pangea-node-sdk: refactor publish pipeline around Git tags (GEA-12973)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,12 +22,12 @@ stages:
         - node_modules
 
 include:
-  - /packages/react-mui-shared/.gitlab-ci.yml
-  - /packages/react-mui-branding/.gitlab-ci.yml
-  - /packages/react-mui-authn/.gitlab-ci.yml
-  - /packages/react-mui-audit-log-viewer/.gitlab-ci.yml
-  - /packages/react-mui-store-file-viewer/.gitlab-ci.yml
-  - /packages/react-auth/.gitlab-ci.yml
-  - /packages/pangea-node-sdk/.gitlab-ci.yml
-  - /packages/vanilla-js/.gitlab-ci.yml
   - /examples/.examples-ci.yml
+  - /packages/pangea-node-sdk/.gitlab-ci.yml
+  - /packages/react-auth/.gitlab-ci.yml
+  - /packages/react-mui-audit-log-viewer/.gitlab-ci.yml
+  - /packages/react-mui-authn/.gitlab-ci.yml
+  - /packages/react-mui-branding/.gitlab-ci.yml
+  - /packages/react-mui-shared/.gitlab-ci.yml
+  - /packages/react-mui-store-file-viewer/.gitlab-ci.yml
+  - /packages/vanilla-js/.gitlab-ci.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,29 @@ $ yarn install
 $ yarn generate:docs
 ```
 
+## Publishing pangea-node-sdk
+
+Publishing pangea-node-sdk to the npm registry is handled via a private GitLab
+CI pipeline. This pipeline is triggered when a Git tag is pushed to the
+repository. Git tags should be formatted as `pangea-node-sdk/vX.Y.Z`, where
+`vX.Y.Z` is the [Semantic Versioning][]-compliant version number to publish.
+
+1. Update the `"version"` field in `packages/pangea-node-sdk/package.json`.
+2. Update the `version` constant in `packages/pangea-node-sdk/src/config.ts`.
+3. Update the release notes in `packages/pangea-node-sdk/CHANGELOG.md`.
+4. Author a commit with this change and land it on a remote branch.
+5. `git tag -m pangea-node-sdk/vX.Y.Z pangea-node-sdk/vX.Y.Z 0000000`. Replace
+   `vX.Y.Z` with the new version number and `0000000` with the commit SHA from
+   the previous step.
+6. `git push --tags origin <branch>`.
+
+From here the GitLab CI pipeline will pick up the pushed Git tag and publish
+the package to the npm registry.
+
 ## Contributors:
 
 - Andrés Tournour (andres.tournour@gmail.com). Code.
 - Glenn Gallien (glenn.gallien@pangea.cloud). Code and docs.
 - David Wayman (david.wayman@pangea.cloud). Code and docs.
+
+[Semantic Versioning]: https://semver.org/

--- a/dev/validate_tag.sh
+++ b/dev/validate_tag.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ $# -lt 1 ]; then
+    echo "usage: validate_tag.sh <git_tag>"
+    exit 1
+fi
+
+GIT_TAG=$1
+
+if [[ ! $GIT_TAG == *"/"* ]]; then
+   echo "Git tag must contain a forward slash to delimit the package name from the version number."
+   exit 1
+fi
+
+PACKAGE_NAME=$(echo "$GIT_TAG" | cut -d "/" -f 1)
+VERSION=$(echo "$GIT_TAG" | cut -d "/" -f 2)
+
+if [[ ! "$VERSION" == *"v"* ]]; then
+   echo "Git tag must contain a version number that's prefixed with 'v'."
+   exit 1
+fi
+
+# Move to repo root.
+PARENT_PATH=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)
+pushd "$PARENT_PATH/.."
+
+PACKAGEJSON_VERSION=v$(npm view packages/pangea-node-sdk/ version)
+
+if [[ ! "$VERSION" == "$PACKAGEJSON_VERSION" ]]; then
+   echo "Git tag version '$VERSION' does not match package.json version '$PACKAGEJSON_VERSION'."
+   exit 1
+fi
+
+popd

--- a/examples/.examples-ci.yml
+++ b/examples/.examples-ci.yml
@@ -14,11 +14,6 @@ examples-tests:
           - "intel"
           - "redact"
           - "vault"
-  rules:
-    - changes:
-        - examples/**/*
-        - packages/pangea-node-sdk/**/*
-
   image: node:${NODE_VERSION}
   before_script:
     - export PANGEA_AUDIT_CONFIG_ID="${PANGEA_AUDIT_CONFIG_ID_1_LVE_AWS}"
@@ -46,3 +41,8 @@ examples-tests:
     - cd examples/${TEST_FOLDER}
     - yarn install --frozen-lockfile
     - bash ../../dev/run_all_examples.sh
+  rules:
+    - if: $CI_COMMIT_BRANCH
+    - changes:
+        - examples/**/*
+        - packages/pangea-node-sdk/**/*

--- a/packages/pangea-node-sdk/.gitlab-ci.yml
+++ b/packages/pangea-node-sdk/.gitlab-ci.yml
@@ -93,7 +93,7 @@ pangea-node-sdk-integration-tests:
         ENV: ${SERVICE_VAULT_ENV}
         TEST: vault
   rules:
-    - if: '$CI_COMMIT_BRANCH || $CI_PIPELINE_SOURCE == "push"'
+    - if: $CI_COMMIT_BRANCH
       changes:
         - examples/**/*
         - packages/pangea-node-sdk/**/*
@@ -109,24 +109,6 @@ pangea-node-sdk-integration-tests-may-fail:
         TEST: file_scan
   allow_failure: true
 
-.pangea-node-sdk-publish:
-  before_script:
-    - cd packages/pangea-node-sdk
-    - yarn install --frozen-lockfile
-    - apt update -y
-    - apt install -y jq
-  cache:
-    - key:
-        files:
-          - packages/pangea-node-sdk/yarn.lock
-      paths:
-        - packages/pangea-node-sdk/node_modules
-  rules:
-    - if: $CI_COMMIT_BRANCH == "release"
-      changes:
-        - packages/pangea-node-sdk/**/*
-      when: on_success
-
 pangea-node-sdk-build:
   extends: .pangea-node-sdk-base
   stage: build
@@ -135,10 +117,6 @@ pangea-node-sdk-build:
   artifacts:
     paths: ["packages/pangea-node-sdk/dist"]
     when: on_success
-  rules:
-    - changes:
-        - examples/**/*
-        - packages/pangea-node-sdk/**/*
 
 pangea-node-sdk-pack:
   extends: .pangea-node-sdk-base
@@ -149,10 +127,6 @@ pangea-node-sdk-pack:
   artifacts:
     paths: ["packages/pangea-node-sdk/pangea-node-sdk-v*.tgz"]
     when: on_success
-  rules:
-    - changes:
-        - examples/**/*
-        - packages/pangea-node-sdk/**/*
 
 pangea-node-sdk-lint:
   extends: .pangea-node-sdk-base
@@ -161,19 +135,25 @@ pangea-node-sdk-lint:
     - yarn lint
 
 pangea-node-sdk-publish:
-  extends: .pangea-node-sdk-publish
+  needs: [pangea-node-sdk-build, pangea-node-sdk-pack]
   stage: publish
+  cache:
+    - key:
+        files:
+          - packages/pangea-node-sdk/yarn.lock
+      paths:
+        - packages/pangea-node-sdk/node_modules
   script:
+    - apt update -y
+    - apt install -y jq
+
+    - bash ../../dev/validate_tag.sh $CI_COMMIT_TAG
+
+    - cd packages/pangea-node-sdk
+    - yarn install --frozen-lockfile
+
     - cp ../../scripts/publish.sh .
     - echo "${NPMRC}" > .npmrc && ./publish.sh && rm .npmrc
     - rm publish.sh
-
-pangea-node-sdk-tag-release:
-  extends: .pangea-node-sdk-publish
-  stage: tag_release
-  script:
-    - apt install -y python3 python3-github
-    - VERSION=$(node -p "require('./package.json').version")
-    - cp ../../scripts/tag_release.py .
-    - python3 tag_release.py ${GITHUB_TOKEN} ${VERSION} ${CI_COMMIT_SHA} "pangea-node-sdk" "Pangea Node SDK"
-    - rm tag_release.py
+  rules:
+    - if: $CI_COMMIT_TAG =~ /pangea-node-sdk\/.+/


### PR DESCRIPTION
Publishing to the npm registry is now triggered via the pushing of Git tags instead of requiring the use of the one `release` branch. This enables flexibility in publishing prerelease versions outside of the `release` branch and shaves one step off of the manual release process (merging to `release`).

Instructions on how to publish a new version going forward have been added to `CONTRIBUTING.md`.

This only affects pangea-node-sdk because I did not want to disrupt how the other projects are being worked on at the moment. However, the changes here are versatile enough that it would be very easy for the other projects to "onboard".