### PR TITLE
react-auth: mark client entry points (GEA-13856)

### DIFF
--- a/packages/react-auth/.parcelrc
+++ b/packages/react-auth/.parcelrc
@@ -1,0 +1,6 @@
+{
+  "extends": "@parcel/config-default",
+  "optimizers": {
+    "*.{js,mjs,cjs}": ["./parcel-optimizer-use-client.mjs"]
+  }
+}

--- a/packages/react-auth/package.json
+++ b/packages/react-auth/package.json
@@ -45,8 +45,12 @@
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.15.3",
     "@babel/core": "^7.24.4",
+    "@parcel/config-default": "^2.12.0",
     "@parcel/packager-ts": "^2.12.0",
+    "@parcel/plugin": "^2.12.0",
+    "@parcel/source-map": "^2.1.1",
     "@parcel/transformer-typescript-types": "^2.12.0",
+    "@parcel/utils": "^2.12.0",
     "@tsconfig/strictest": "^2.0.5",
     "@types/lodash": "^4.17.0",
     "@types/react": "^18.2.79",

--- a/packages/react-auth/parcel-optimizer-use-client.mjs
+++ b/packages/react-auth/parcel-optimizer-use-client.mjs
@@ -1,0 +1,22 @@
+// <https://github.com/parcel-bundler/parcel/issues/9050#issuecomment-1565658989>
+
+import { Optimizer } from "@parcel/plugin";
+import utils from "@parcel/utils";
+import SourceMap from "@parcel/source-map";
+
+export default new Optimizer({
+  async optimize({ contents, map, options }) {
+    let correctMap;
+    if (map != null) {
+      correctMap = new SourceMap.default(options.projectRoot);
+      correctMap.addSourceMap(map, 1); // 1 = offset lines by 1
+    }
+
+    const origContents = await utils.blobToString(contents);
+    const nextContents = /use client/g.test(origContents)
+      ? '"use client";\n\n' + origContents.replaceAll('"use client";', "")
+      : origContents;
+
+    return { contents: nextContents, map: correctMap };
+  },
+});

--- a/packages/react-auth/src/AuthNFlow/mock.tsx
+++ b/packages/react-auth/src/AuthNFlow/mock.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   FC,
   ReactNode,

--- a/packages/react-auth/src/AuthNFlow/provider.tsx
+++ b/packages/react-auth/src/AuthNFlow/provider.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   FC,
   ReactNode,

--- a/packages/react-auth/src/AuthProvider/index.tsx
+++ b/packages/react-auth/src/AuthProvider/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   FC,
   createContext,

--- a/packages/react-auth/src/ComponentAuthProvider/index.tsx
+++ b/packages/react-auth/src/ComponentAuthProvider/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   FC,
   createContext,

--- a/packages/react-auth/yarn.lock
+++ b/packages/react-auth/yarn.lock
@@ -389,7 +389,7 @@
   dependencies:
     "@parcel/plugin" "2.12.0"
 
-"@parcel/config-default@2.12.0":
+"@parcel/config-default@2.12.0", "@parcel/config-default@^2.12.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@parcel/config-default/-/config-default-2.12.0.tgz#7b213348db349c6042a80dfd4a7eab707a1dfbfa"
   integrity sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==
@@ -665,7 +665,7 @@
   dependencies:
     "@parcel/plugin" "2.12.0"
 
-"@parcel/plugin@2.12.0":
+"@parcel/plugin@2.12.0", "@parcel/plugin@^2.12.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@parcel/plugin/-/plugin-2.12.0.tgz#3db4237e8977ef5b5378b65eaffb809d2026431a"
   integrity sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==
@@ -933,7 +933,7 @@
     "@parcel/workers" "2.12.0"
     utility-types "^3.10.0"
 
-"@parcel/utils@2.12.0":
+"@parcel/utils@2.12.0", "@parcel/utils@^2.12.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@parcel/utils/-/utils-2.12.0.tgz#ac900726e7cb12a9e6392081fa05b756183f65fd"
   integrity sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==


### PR DESCRIPTION
Use the `"use client";` directive on any component that depends on state and lifecycle events.

Added a custom Parcel optimizer plugin to ensure that the `"use client";` directive appears at the top of the bundled files, which is a requirement of that directive.

Verified working locally on a Next.js v14.2.2 app with App Router enabled.