### PR TITLE
pangea-node-sdk: run base CI on any type of push (GEA-14406)

### DIFF
--- a/packages/pangea-node-sdk/.gitlab-ci.yml
+++ b/packages/pangea-node-sdk/.gitlab-ci.yml
@@ -9,8 +9,7 @@
       paths:
         - packages/pangea-node-sdk/node_modules
   rules:
-    - if: $CI_COMMIT_BRANCH
-      changes:
+    - changes:
         - examples/**/*
         - packages/pangea-node-sdk/**/*
       when: on_success


### PR DESCRIPTION
Limiting the base CI to just branch pushes is not really necessary, and we want it to run on tag pushes as well. So, remove the `if` rule.