### PR TITLE
pangea-node-sdk mark `BaseService.post()` as internal (GEA-14490)

### DIFF
--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `BaseService.post()` is now `protected` and `@internal`, as it was never meant
+  for public use.
+
 ### Removed
 
 - Beta tags from AuthZ.

--- a/packages/pangea-node-sdk/src/services/base.ts
+++ b/packages/pangea-node-sdk/src/services/base.ts
@@ -41,13 +41,14 @@ class BaseService {
   /**
    * `POST` request.
    *
+   * @internal
    * @template R Result type.
    * @param endpoint Endpoint path.
    * @param data Request body.
    * @param options Additional options.
    * @returns A `Promise` of the response.
    */
-  async post<R>(
+  protected async post<R>(
     endpoint: string,
     data: object,
     options: PostOptions = {}


### PR DESCRIPTION
This method is appearing in API docs because it is `public` and not marked as `@internal`. However, this isn't intended for public use by API consumers, so this patch updates it to be `protected` and `@internal`.