### PR TITLE
pangea-node-sdk: remove `first_name` and `last_name` (PAN-15304)

### DIFF
--- a/packages/pangea-node-sdk/src/types.ts
+++ b/packages/pangea-node-sdk/src/types.ts
@@ -1555,8 +1555,6 @@ export namespace AuthN {
 
   export interface Profile {
     [key: string]: string | undefined;
-    first_name?: string;
-    last_name?: string;
   }
 
   export enum MFAProvider {


### PR DESCRIPTION
No effect on public API, `Profile.first_name` is still accessible, these fields just won't be an explicit part of all profiles going forward.