### PR TITLE
pangea-node-sdk: add `"state"` to `Authenticator` (PAN-15469)

### DIFF
--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CommonJS support.
 - Vault `/export` support.
 - AuthN user password expiration support.
+- `"state"` and other new properties to `AuthN.User.Authenticators.Authenticator`.
+
+### Changed
+
+- `enable` in `AuthN.User.Authenticators.Authenticator` has been renamed to
+  `enabled`. The previous name did not match the name used in the API's response
+  schema so it was unusable anyways.
 
 ## [3.9.0] - 2024-06-07
 

--- a/packages/pangea-node-sdk/src/types.ts
+++ b/packages/pangea-node-sdk/src/types.ts
@@ -2253,16 +2253,47 @@ export namespace AuthN {
         username?: string;
       }
 
+      /** Authenticator. */
       export interface Authenticator {
+        /** An ID for an authenticator. */
         id: string;
+
+        /** An authentication mechanism. */
         type: string;
-        enable: boolean;
+
+        /** Enabled. */
+        enabled: boolean;
+
+        /** Provider. */
         provider?: string;
+
+        /** Provider name. */
+        provider_name?: string;
+
+        /** RPID. */
         rpid: string;
+
+        /** Phase. */
         phase: string;
+
+        /** Enrolling browser. */
+        enrolling_browser?: string;
+
+        /** Enrolling IP. */
+        enrolling_ip?: string;
+
+        /** A time in ISO-8601 format. */
+        created_at: string;
+
+        /** A time in ISO-8601 format. */
+        updated_at: string;
+
+        /** State. */
+        state?: string;
       }
 
       export interface ListResult {
+        /** A list of authenticators. */
         authenticators: Authenticator[];
       }
     }


### PR DESCRIPTION
Also added other missing properties. Many of these do not have descriptions in the API documentation so the docs here are skim.

`enable` has been renamed to `enabled` to match the API's response schema. This is a breaking change but the current property isn't being deserialized properly anyways so it's been unusable this whole time.