### PR TITLE
Create new Pangea token type

### DIFF
--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AuthN `getProfile()` TSDoc example.
 - Non-ASCII values not being escaped properly during event canonicalization.
 
+### Changed
+
+- Service constructors now support Vault service's `GetResult` type as well as strings as tokens.
+
 ## [3.10.0] - 2024-07-16
 
 ### Added

--- a/packages/pangea-node-sdk/src/services/audit.ts
+++ b/packages/pangea-node-sdk/src/services/audit.ts
@@ -1,7 +1,7 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "./base.js";
 import PangeaConfig from "@src/config.js";
-import { Audit, PostOptions } from "@src/types.js";
+import { Audit, PangeaToken, PostOptions } from "@src/types.js";
 import {
   PublishedRoots,
   getArweavePublishedRoots,
@@ -45,7 +45,7 @@ class AuditService extends BaseService {
    * @summary Audit
    */
   constructor(
-    token: string,
+    token: PangeaToken,
     config: PangeaConfig,
     tenantID?: string,
     configID?: string

--- a/packages/pangea-node-sdk/src/services/authn/agreements/index.ts
+++ b/packages/pangea-node-sdk/src/services/authn/agreements/index.ts
@@ -1,10 +1,10 @@
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
 import PangeaResponse from "@src/response.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class Agreements extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authn/client/index.ts
+++ b/packages/pangea-node-sdk/src/services/authn/client/index.ts
@@ -1,7 +1,7 @@
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
 import PangeaResponse from "@src/response.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 import ClientSession from "./session.js";
 import ClientPassword from "./password.js";
@@ -12,7 +12,7 @@ export default class Client extends BaseService {
   password: ClientPassword;
   clientToken: ClientToken;
 
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
 
     this.session = new ClientSession(token, config);

--- a/packages/pangea-node-sdk/src/services/authn/client/password.ts
+++ b/packages/pangea-node-sdk/src/services/authn/client/password.ts
@@ -1,10 +1,10 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class ClientPassword extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authn/client/session.ts
+++ b/packages/pangea-node-sdk/src/services/authn/client/session.ts
@@ -1,10 +1,10 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class ClientSession extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authn/client/token.ts
+++ b/packages/pangea-node-sdk/src/services/authn/client/token.ts
@@ -1,10 +1,10 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class ClientToken extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authn/flow/index.ts
+++ b/packages/pangea-node-sdk/src/services/authn/flow/index.ts
@@ -1,10 +1,10 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class Flow extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authn/index.ts
+++ b/packages/pangea-node-sdk/src/services/authn/index.ts
@@ -5,6 +5,7 @@ import Flow from "./flow/index.js";
 import Client from "./client/index.js";
 import Session from "./session.js";
 import Agreements from "./agreements/index.js";
+import {PangeaToken} from "@src/types.js";
 
 /**
  * AuthnService class provides methods for interacting with the AuthN Service
@@ -32,7 +33,7 @@ class AuthNService extends BaseService {
    *
    * @summary AuthN
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
 
     this.user = new User(token, config);

--- a/packages/pangea-node-sdk/src/services/authn/index.ts
+++ b/packages/pangea-node-sdk/src/services/authn/index.ts
@@ -5,7 +5,7 @@ import Flow from "./flow/index.js";
 import Client from "./client/index.js";
 import Session from "./session.js";
 import Agreements from "./agreements/index.js";
-import {PangeaToken} from "@src/types.js";
+import { PangeaToken } from "@src/types.js";
 
 /**
  * AuthnService class provides methods for interacting with the AuthN Service

--- a/packages/pangea-node-sdk/src/services/authn/session.ts
+++ b/packages/pangea-node-sdk/src/services/authn/session.ts
@@ -1,10 +1,10 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class Session extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authn/user/authenticators.ts
+++ b/packages/pangea-node-sdk/src/services/authn/user/authenticators.ts
@@ -1,10 +1,10 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class UserAuthenticators extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authn/user/index.ts
+++ b/packages/pangea-node-sdk/src/services/authn/user/index.ts
@@ -1,7 +1,7 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 import UserProfile from "./profile.js";
 import UserAuthenticators from "./authenticators.js";
 import UserInvites from "./invites.js";
@@ -11,7 +11,7 @@ export default class User extends BaseService {
   authenticators: UserAuthenticators;
   invites: UserInvites;
 
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
 
     this.profile = new UserProfile(token, config);

--- a/packages/pangea-node-sdk/src/services/authn/user/invites.ts
+++ b/packages/pangea-node-sdk/src/services/authn/user/invites.ts
@@ -1,10 +1,10 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class UserInvites extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authn/user/profile.ts
+++ b/packages/pangea-node-sdk/src/services/authn/user/profile.ts
@@ -1,10 +1,10 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "@src/services/base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthN } from "@src/types.js";
+import { AuthN, PangeaToken } from "@src/types.js";
 
 export default class UserProfile extends BaseService {
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authn", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/authz.ts
+++ b/packages/pangea-node-sdk/src/services/authz.ts
@@ -1,7 +1,7 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "./base.js";
 import PangeaConfig from "@src/config.js";
-import { AuthZ } from "@src/types.js";
+import { AuthZ, PangeaToken } from "@src/types.js";
 
 /**
  * AuthZService class provides methods for interacting with the AuthZ Service
@@ -23,7 +23,7 @@ class AuthZService extends BaseService {
    *
    * @summary AuthZ
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("authz", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/base.ts
+++ b/packages/pangea-node-sdk/src/services/base.ts
@@ -1,7 +1,7 @@
 import PangeaConfig from "@src/config.js";
 import PangeaRequest from "@src/request.js";
 import PangeaResponse, { AttachedFile } from "@src/response.js";
-import { PostOptions, Vault, PangeaToken } from "@src/types.js";
+import { PostOptions, PangeaToken } from "@src/types.js";
 
 class BaseService {
   protected serviceName: string;

--- a/packages/pangea-node-sdk/src/services/base.ts
+++ b/packages/pangea-node-sdk/src/services/base.ts
@@ -46,7 +46,7 @@ class BaseService {
           "Token passed as vault secret does not have a current version"
         );
       if (currentVersion.state !== "active")
-        throw new Error("Token passed as vault secret is not current active");
+        throw new Error("Token passed as vault secret is not currently active");
       if (!currentVersion.secret)
         throw new Error(
           "Vault secret field is not populated, cannot pass as token"

--- a/packages/pangea-node-sdk/src/services/embargo.ts
+++ b/packages/pangea-node-sdk/src/services/embargo.ts
@@ -1,7 +1,7 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "./base.js";
 import PangeaConfig from "@src/config.js";
-import { Embargo } from "@src/types.js";
+import { Embargo, PangeaToken } from "@src/types.js";
 
 /**
  * EmbargoService class provides methods for interacting with the Embargo Service
@@ -23,7 +23,7 @@ class EmbargoService extends BaseService {
    *
    * @summary Embargo
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("embargo", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/file_scan.ts
+++ b/packages/pangea-node-sdk/src/services/file_scan.ts
@@ -7,6 +7,7 @@ import {
   PostOptions,
   TransferMethod,
   FileItems,
+  PangeaToken,
 } from "@src/types.js";
 import { getFileUploadParams } from "@src/utils/utils.js";
 import { PangeaErrors } from "@src/errors.js";
@@ -28,7 +29,7 @@ export class FileScanService extends BaseService {
    *
    * @summary File Scan
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("file-scan", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/intel.ts
+++ b/packages/pangea-node-sdk/src/services/intel.ts
@@ -1,7 +1,7 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "./base.js";
 import PangeaConfig from "@src/config.js";
-import { Intel } from "@src/types.js";
+import { Intel, PangeaToken } from "@src/types.js";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { PangeaErrors } from "@src/errors.js";
@@ -48,7 +48,7 @@ export class FileIntelService extends BaseService {
    *
    * @summary File Intel
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("file-intel", token, config);
   }
 
@@ -242,7 +242,7 @@ export class DomainIntelService extends BaseService {
    *
    * @summary Domain Intel
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("domain-intel", token, config);
   }
 
@@ -389,7 +389,7 @@ export class IPIntelService extends BaseService {
    *
    * @summary IP Intel
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("ip-intel", token, config);
   }
 
@@ -793,7 +793,7 @@ export class URLIntelService extends BaseService {
    *
    * @summary URL Intel
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("url-intel", token, config);
   }
 
@@ -910,7 +910,7 @@ export class UserIntelService extends BaseService {
    *
    * @summary User Intel
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("user-intel", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/services/redact.ts
+++ b/packages/pangea-node-sdk/src/services/redact.ts
@@ -1,7 +1,7 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "./base.js";
 import PangeaConfig from "@src/config.js";
-import { Redact } from "@src/types.js";
+import { PangeaToken, Redact } from "@src/types.js";
 
 export interface RedactOptions {
   config_id?: string;
@@ -28,7 +28,7 @@ class RedactService extends BaseService {
    * @summary Redact
    */
   constructor(
-    token: string,
+    token: PangeaToken,
     config: PangeaConfig,
     options: RedactOptions = {}
   ) {

--- a/packages/pangea-node-sdk/src/services/vault.ts
+++ b/packages/pangea-node-sdk/src/services/vault.ts
@@ -1,7 +1,7 @@
 import PangeaResponse from "@src/response.js";
 import BaseService from "./base.js";
 import PangeaConfig from "@src/config.js";
-import { Vault } from "@src/types.js";
+import { PangeaToken, Vault } from "@src/types.js";
 
 /**
  * VaultService class provides methods for interacting with the Vault Service
@@ -23,7 +23,7 @@ class VaultService extends BaseService {
    *
    * @summary Vault
    */
-  constructor(token: string, config: PangeaConfig) {
+  constructor(token: PangeaToken, config: PangeaConfig) {
     super("vault", token, config);
   }
 

--- a/packages/pangea-node-sdk/src/types.ts
+++ b/packages/pangea-node-sdk/src/types.ts
@@ -43,6 +43,8 @@ export interface ConfigOptions {
   customUserAgent?: string;
 }
 
+export type PangeaToken = string | { type: "pangea_token" } & Vault.GetResult
+
 export interface PostOptions {
   pollResultSync?: boolean;
   files?: FileItems;
@@ -825,7 +827,7 @@ export namespace Vault {
   }
 
   export enum ItemState {
-    ENABLED = "ENABLED",
+    ENABLED = "enabled",
     DISABLED = "disabled",
   }
 

--- a/packages/pangea-node-sdk/src/types.ts
+++ b/packages/pangea-node-sdk/src/types.ts
@@ -43,7 +43,7 @@ export interface ConfigOptions {
   customUserAgent?: string;
 }
 
-export type PangeaToken = string | { type: "pangea_token" } & Vault.GetResult
+export type PangeaToken = string | ({ type: "pangea_token" } & Vault.GetResult);
 
 export interface PostOptions {
   pollResultSync?: boolean;

--- a/packages/pangea-node-sdk/src/utils/multipart.ts
+++ b/packages/pangea-node-sdk/src/utils/multipart.ts
@@ -56,7 +56,7 @@ export function parse(multipartBodyBuffer: Buffer, boundary: string): Input[] {
   for (let i = 0; i < multipartBodyBuffer.length; i++) {
     const oneByte: number = multipartBodyBuffer[i] ?? 0;
     const prevByte: number | null =
-      i > 0 ? multipartBodyBuffer[i - 1] ?? 0 : null;
+      i > 0 ? (multipartBodyBuffer[i - 1] ?? 0) : null;
     // 0x0a => \n
     // 0x0d => \r
     const newLineDetected: boolean = oneByte === 0x0a && prevByte === 0x0d;

--- a/packages/pangea-node-sdk/src/utils/multipart.ts
+++ b/packages/pangea-node-sdk/src/utils/multipart.ts
@@ -56,7 +56,7 @@ export function parse(multipartBodyBuffer: Buffer, boundary: string): Input[] {
   for (let i = 0; i < multipartBodyBuffer.length; i++) {
     const oneByte: number = multipartBodyBuffer[i] ?? 0;
     const prevByte: number | null =
-      i > 0 ? (multipartBodyBuffer[i - 1] ?? 0) : null;
+      i > 0 ? multipartBodyBuffer[i - 1] ?? 0 : null;
     // 0x0a => \n
     // 0x0d => \r
     const newLineDetected: boolean = oneByte === 0x0a && prevByte === 0x0d;


### PR DESCRIPTION
Accept Pangea token type in service constructors. Type must be 'pangea_token' or a raw string.