### PR TITLE
pangea-node-sdk: raise timeout of Audit tests (PAN-16504)

### DIFF
--- a/packages/pangea-node-sdk/tests/integration/audit.test.ts
+++ b/packages/pangea-node-sdk/tests/integration/audit.test.ts
@@ -67,7 +67,10 @@ const auditVault = new AuditService(tokenVault, config);
 const auditWithTenantId = new AuditService(tokenGeneral, config, "mytenantid");
 const auditCustomSchema = new AuditService(tokenCustomSchema, config);
 
-jest.setTimeout(60000);
+// Polling should finish before the test times out, so set the test timeout to
+// the polling duration plus some buffer.
+jest.setTimeout(config.pollResultTimeoutMs + 1000);
+
 it("log an audit event. no verbose", async () => {
   const event: Audit.Event = {
     actor: ACTOR,
@@ -586,7 +589,6 @@ it("custom schema log an audit event in JSON format, local sign and verify", asy
   });
 });
 
-jest.setTimeout(20000);
 it("search audit log and verify signature", async () => {
   const query = "message:" + MSG_SIGNED_LOCAL + " status:" + STATUS_SIGNED;
   const limit = 2;


### PR DESCRIPTION
Timeout was being set to 60s early on in the file, but then overwritten to 20s later on. This affects all tests here.

Both of these values are less than the default polling timeout of 120s, so this patch removes the duplicate `jest.setTimeout()` and sets the overall test timeout to the polling timeout plus some buffer. This way the polling timeout is hit before the test timeout.