### PR TITLE
pangea-node-sdk: correct canonicalization of more chars (PAN-16573)

### DIFF
--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Event canonicalization of characters like a-circumflex and the replacement
+  character.
+
 ## 3.11.0 - 2024-07-30
 
 ### Added

--- a/packages/pangea-node-sdk/package.json
+++ b/packages/pangea-node-sdk/package.json
@@ -30,6 +30,7 @@
     "crypto-js": "^4.2.0",
     "form-data-encoder": "^4.0.2",
     "formdata-node": "^6.0.3",
+    "json-canon": "^1.0.1",
     "merkle-tools": "^1.4.1",
     "promise-retry": "^2.0.1"
   },

--- a/packages/pangea-node-sdk/src/json-canon.d.ts
+++ b/packages/pangea-node-sdk/src/json-canon.d.ts
@@ -1,0 +1,4 @@
+declare module "json-canon" {
+  declare function serialize(value: unknown): string;
+  export = serialize;
+}

--- a/packages/pangea-node-sdk/tests/unit/utils.test.ts
+++ b/packages/pangea-node-sdk/tests/unit/utils.test.ts
@@ -10,7 +10,11 @@ import {
   b64toStr,
   hashNTLM,
 } from "@src/index.js";
-import { canonicalize, getFileUploadParams } from "@src/utils/utils.js";
+import {
+  canonicalize,
+  canonicalizeEnvelope,
+  getFileUploadParams,
+} from "@src/utils/utils.js";
 import { verifyLogHash } from "@src/utils/verification.js";
 
 const testfilePath = "./tests/testdata/testfile.pdf";
@@ -72,10 +76,10 @@ it("PAN-15851: canonicalization escaping", () => {
   expect(canonicalize({ foo: "'" })).toEqual(`{"foo":"'"}`);
   expect(canonicalize({ foo: "`" })).toEqual('{"foo":"`"}');
   expect(canonicalize({ foo: `"` })).toEqual('{"foo":"\\""}');
-  expect(canonicalize({ foo: "❤️" })).toEqual('{"foo":"\\\\u2764\\\\ufe0f"}');
-  expect(canonicalize({ foo: "𝌆" })).toEqual('{"foo":"\\\\ud834\\\\udf06"}');
+  expect(canonicalize({ foo: "❤️" })).toEqual('{"foo":"\u2764\ufe0f"}');
+  expect(canonicalize({ foo: "𝌆" })).toEqual('{"foo":"\ud834\udf06"}');
   expect(canonicalize({ foo: "abc𝔸𝔹ℂ" })).toEqual(
-    '{"foo":"abc\\\\ud835\\\\udd38\\\\ud835\\\\udd39\\\\u2102"}'
+    '{"foo":"abc\ud835\udd38\ud835\udd39\u2102"}'
   );
   /* eslint-enable quotes */
 
@@ -85,13 +89,68 @@ it("PAN-15851: canonicalization escaping", () => {
       action: "Viewed employee records",
       actor: "rob",
       message: "rob viewed Oliver Friedrichs employee details.",
-      new: '{"image":"/people/Oliver_Friedrichs.png","linkedin":"https://www.linkedin.com/in/oliverfriedrichs","name":"Oliver Friedrichs","quote":["I ❤️ SOC2, GDPR, HIPAA, PCI and ISO 27001.","Always give 100%, unless you\'re donating blood.","If you think you are too small to make a difference, try sleeping with a mosquito."],"title":"CEO","twitter":""}',
+      new: '{"image":"/people/Oliver_Friedrichs.png","linkedin":"https://www.linkedin.com/in/oliverfriedrichs","name":"Oliver Friedrichs","quote":["I \\u2764\\ufe0f SOC2, GDPR, HIPAA, PCI and ISO 27001.","Always give 100%, unless you\'re donating blood.","If you think you are too small to make a difference, try sleeping with a mosquito."],"title":"CEO","twitter":""}',
     },
   };
   expect(
     verifyLogHash(
       envelope,
       "e43f028b3d824db1de9e709c652dc4377af0a6422f1248d5654ea42258a777ef"
+    )
+  ).toStrictEqual(true);
+});
+
+it("canon envelope dates", () => {
+  const sample = { event: { custom: new Date("1995-12-17T03:24:00Z") } };
+  expect(canonicalizeEnvelope(sample)).toEqual(
+    '{"event":{"custom":"1995-12-17T03:24:00.000Z"}}'
+  );
+});
+
+it("canon envelope nested objects", () => {
+  const sample = {
+    received_at: "2024-09-03T22:08:32.694255Z",
+    event: {
+      actor: "node-sdk",
+      message: "JSON-message",
+      new: { customtag3: "mycustommsg3", ct4: "cm4" },
+      old: { customtag5: "mycustommsg5", ct6: "cm6" },
+      status: "no-signed",
+    },
+  };
+  expect(canonicalizeEnvelope(sample)).toEqual(
+    '{"event":{"actor":"node-sdk","message":"JSON-message","new":"{\\"ct4\\":\\"cm4\\",\\"customtag3\\":\\"mycustommsg3\\"}","old":"{\\"ct6\\":\\"cm6\\",\\"customtag5\\":\\"mycustommsg5\\"}","status":"no-signed"},"received_at":"2024-09-03T22:08:32.694255Z"}'
+  );
+});
+
+it("PAN-16573: canonicalize a-circumflex", () => {
+  const envelope = {
+    received_at: "2024-09-03T20:01:38.704822Z",
+    event: { message: "â" },
+  };
+  expect(canonicalizeEnvelope(envelope)).toEqual(
+    '{"event":{"message":"â"},"received_at":"2024-09-03T20:01:38.704822Z"}'
+  );
+  expect(
+    verifyLogHash(
+      envelope,
+      "77bb9ccd63d232e6c440d03c088f4723b146047d1dfa301bd69b82723a19a6fb"
+    )
+  ).toStrictEqual(true);
+});
+
+it("PAN-16573: canonicalize a-circumflex + replacement character", () => {
+  const envelope = {
+    received_at: "2024-08-27T19:35:14.005407Z",
+    event: { message: "â\uFFFD" },
+  };
+  expect(canonicalizeEnvelope(envelope)).toEqual(
+    '{"event":{"message":"\u00e2\ufffd"},"received_at":"2024-08-27T19:35:14.005407Z"}'
+  );
+  expect(
+    verifyLogHash(
+      envelope,
+      "2195d3522099699c949732d2449a45e490ec3818f69ca7c021232c03a1ba9798"
     )
   ).toStrictEqual(true);
 });

--- a/packages/pangea-node-sdk/yarn.lock
+++ b/packages/pangea-node-sdk/yarn.lock
@@ -3343,6 +3343,11 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-canon@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-canon/-/json-canon-1.0.1.tgz#ce815a1d02e1b02c97b21154c7a844321e314184"
+  integrity sha512-PQcj4PFOTAQxE8PgoQ4KrM0DcKWZd7S3ELOON8rmysl9I8JuFMgxu1H9v+oZsTPjjkpeS3IHPwLjr7d+gKygnw==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"


### PR DESCRIPTION
Integration tests unveiled more canonicalization issues, this time surrounding the a-circumflex and replacement characters: <https://gitlab.com/pangeacyber/pangea-javascript/-/jobs/7734561427>

This patch fixes the issue by replacing all of the custom RFC8785 code with the json-canon library. Also added unit tests to cover what was previously failing.