### PR TITLE
Share UX updates

### DIFF
--- a/packages/react-mui-authn/CHANGELOG.md
+++ b/packages/react-mui-authn/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.13] - 2024-09-16
+
+### Fixed
+
+- Onetime: removed title on auth methods, added password text
+
 ## [0.5.12] - 2024-09-14
 
 ### Fixed

--- a/packages/react-mui-authn/package.json
+++ b/packages/react-mui-authn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pangeacyber/react-mui-authn",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Components for integration with Pangea AuthN Service",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-mui-authn/src/features/AuthFlow/components/AuthOnetimeEmail/index.tsx
+++ b/packages/react-mui-authn/src/features/AuthFlow/components/AuthOnetimeEmail/index.tsx
@@ -36,7 +36,7 @@ const AuthOnetimeEmail: FC<AuthFlowComponentProps> = (props) => {
     <Stack gap={2} width="100%">
       <form onSubmit={formik.handleSubmit} style={{ width: "100%" }}>
         <Stack gap={1}>
-          <BodyText>Confirm your email.</BodyText>
+          <BodyText>Confirm your email</BodyText>
           <StringField
             name="email"
             label="Email"

--- a/packages/react-mui-authn/src/features/AuthFlow/components/AuthOnetimePhone/index.tsx
+++ b/packages/react-mui-authn/src/features/AuthFlow/components/AuthOnetimePhone/index.tsx
@@ -42,7 +42,7 @@ const AuthOnetimePhone: FC<AuthFlowComponentProps> = (props) => {
     <Stack gap={2} width="100%">
       <form onSubmit={formik.handleSubmit} style={{ width: "100%" }}>
         <Stack gap={1}>
-          <BodyText>Confirm your phone number.</BodyText>
+          <BodyText>Confirm your phone number</BodyText>
           <StringField
             name="phone"
             label="Phone Number"

--- a/packages/react-mui-authn/src/features/AuthFlow/components/AuthPassword/index.tsx
+++ b/packages/react-mui-authn/src/features/AuthFlow/components/AuthPassword/index.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useState } from "react";
 import omit from "lodash/omit";
 import { useFormik } from "formik";
 import * as yup from "yup";
-import { Stack } from "@mui/material";
+import { Stack, Typography } from "@mui/material";
 
 import { AuthFlow } from "@pangeacyber/vanilla-js";
 
@@ -16,6 +16,7 @@ import StringField from "@src/components/fields/StringField";
 import VerifyCaptcha from "../VerifyCaptcha";
 import RememberUser from "../RememberUser";
 import PasskeyAuth from "../PasskeyAuth";
+import { BodyText } from "@src/components/core/Text";
 
 const AuthPassword: FC<AuthFlowComponentProps> = (props) => {
   const { options, data, loading, error, update, restart } = props;
@@ -96,7 +97,7 @@ const AuthPassword: FC<AuthFlowComponentProps> = (props) => {
     }
 
     if (data.phase === "phase_one_time") {
-      return "Continue";
+      return options.submitLabel || "Submit";
     }
 
     return options.passwordButtonLabel || "Log in";
@@ -122,6 +123,9 @@ const AuthPassword: FC<AuthFlowComponentProps> = (props) => {
               autoFocus={true}
               hideLabel={true}
             />
+          )}
+          {data.phase === "phase_one_time" && (
+            <BodyText>Enter your password</BodyText>
           )}
           <PasswordField
             name="password"

--- a/packages/react-mui-authn/src/features/AuthFlow/views/Login/index.tsx
+++ b/packages/react-mui-authn/src/features/AuthFlow/views/Login/index.tsx
@@ -13,10 +13,7 @@ const LoginView: FC<AuthFlowComponentProps> = (props) => {
     data.disclaimer && data.phase !== "phase_one_time" ? data.disclaimer : "";
 
   // TODO: Add branding option for onetime title
-  const title =
-    data.phase === "phase_one_time"
-      ? "Confirm your identity"
-      : options.passwordHeading;
+  const title = data.phase === "phase_one_time" ? "" : options.passwordHeading;
 
   return (
     <AuthFlowLayout title={title} disclaimer={disclaimer}>

--- a/packages/react-mui-authn/src/stories/OneTime.stories.tsx
+++ b/packages/react-mui-authn/src/stories/OneTime.stories.tsx
@@ -5,6 +5,8 @@ import { AuthFlowViewOptions } from "../features/AuthFlow/types";
 import LoginView from "../features/AuthFlow/views/Login";
 
 import data_sms from "./data/flow_onetime_sms.json";
+import data_email from "./data/flow_onetime_email.json";
+import data_password from "./data/flow_onetime_password.json";
 
 const update = (data: any) => {};
 
@@ -28,6 +30,18 @@ type Story = StoryObj<typeof FlowOneTime>;
 export const OneTimeSMS: Story = {
   render: (_, context) => {
     return <FlowOneTime options={context.args.options} data={data_sms} />;
+  },
+};
+
+export const OneTimeEmail: Story = {
+  render: (_, context) => {
+    return <FlowOneTime options={context.args.options} data={data_email} />;
+  },
+};
+
+export const OneTimePassword: Story = {
+  render: (_, context) => {
+    return <FlowOneTime options={context.args.options} data={data_password} />;
   },
 };
 

--- a/packages/react-mui-authn/src/stories/data/flow_onetime_email.json
+++ b/packages/react-mui-authn/src/stories/data/flow_onetime_email.json
@@ -1,0 +1,17 @@
+{
+  "flowId": "pfl_flowflowflowflowflowflowflow",
+  "flowType": ["one_time"],
+  "phase": "phase_one_time",
+  "flowChoices": [],
+  "email": "storybook@pangea.cloud",
+  "authChoices": ["set_email"],
+  "socialChoices": [],
+  "socialProviderMap": {},
+  "samlChoices": [],
+  "samlProviderMap": {},
+  "callbackStateMap": {},
+  "agreements": [],
+  "setPhone": {
+    "required_for": ["email_otp"]
+  }
+}

--- a/packages/react-mui-authn/src/stories/data/flow_onetime_password.json
+++ b/packages/react-mui-authn/src/stories/data/flow_onetime_password.json
@@ -1,0 +1,14 @@
+{
+  "flowId": "pfl_flowflowflowflowflowflowflow",
+  "flowType": ["one_time"],
+  "phase": "phase_one_time",
+  "flowChoices": [],
+  "email": "storybook@pangea.cloud",
+  "authChoices": ["password"],
+  "socialChoices": [],
+  "socialProviderMap": {},
+  "samlChoices": [],
+  "samlProviderMap": {},
+  "callbackStateMap": {},
+  "agreements": []
+}

--- a/packages/react-mui-store-file-viewer/CHANGELOG.md
+++ b/packages/react-mui-store-file-viewer/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.66] - 2024-09-16
+
+### Fixed
+
+- "Get Link" password method helper text corrected
+
+### Added
+
+- Show modal with copy password dialog after "Share via Email" password link creation
+
 ## [0.0.65] - 2024-09-04
 
 ### Added

--- a/packages/react-mui-store-file-viewer/package.json
+++ b/packages/react-mui-store-file-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pangeacyber/react-mui-store-file-viewer",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "An extension of material ui data-grid for Pangea store file objects",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/CreateSharesButton/CopyPasswordModal.tsx
+++ b/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/CreateSharesButton/CopyPasswordModal.tsx
@@ -1,0 +1,52 @@
+import { FC } from "react";
+import { Stack, Typography } from "@mui/material";
+import { useTheme, darken, lighten } from "@mui/material/styles";
+import { PangeaModal } from "@pangeacyber/react-mui-shared";
+
+import CopyPasswordButton from "../../PasswordCopyButton";
+
+interface Props {
+  password: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const CopyPasswordModal: FC<Props> = ({ password, open, onClose }) => {
+  const theme = useTheme();
+  const modify = theme.palette.mode === "dark" ? darken : lighten;
+
+  return (
+    <PangeaModal
+      open={open}
+      onClose={onClose}
+      displayCloseIcon
+      header={<Typography variant="h5">Share Link Password</Typography>}
+    >
+      <Stack gap={2}>
+        <Typography variant="body2" color="textSecondary">
+          Be sure to copy this password to your clipboard, you won't be able to
+          access it again.
+        </Typography>
+        <CopyPasswordButton
+          label={password}
+          value={password}
+          variant="contained"
+          disableElevation
+          sx={{
+            bgcolor: modify(theme.palette.info.main, 0.9),
+            color: theme.palette.info.main,
+            ":hover": {
+              bgcolor: modify(theme.palette.info.main, 0.8),
+            },
+            paddingLeft: "0",
+            paddingRight: "0",
+          }}
+        >
+          {password}
+        </CopyPasswordButton>
+      </Stack>
+    </PangeaModal>
+  );
+};
+
+export default CopyPasswordModal;

--- a/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/CreateSharesButton/CreateShareModal.tsx
+++ b/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/CreateSharesButton/CreateShareModal.tsx
@@ -9,8 +9,6 @@ import { FC, forwardRef, useEffect, useMemo, useState } from "react";
 import pickBy from "lodash/pickBy";
 import isEmpty from "lodash/isEmpty";
 import omit from "lodash/omit";
-import keyBy from "lodash/keyBy";
-import mapValues from "lodash/mapValues";
 import * as yup from "yup";
 
 import { useTheme } from "@mui/material/styles";
@@ -28,10 +26,6 @@ import {
 import { ShareCreateForm, getCreateShareFields } from "./fields";
 import ShareSettings from "./ShareSettings";
 import { alertOnError } from "../../AlertSnackbar/hooks";
-import { EmailPasswordShare } from "../SendShareViaEmailButton/EmailPasswordShareField";
-import { EmailSmsShare } from "../SendShareViaEmailButton/EmailSmsShareField";
-
-type ShareSendObj = EmailPasswordShare | EmailSmsShare | undefined;
 
 const CreateButton = forwardRef<any, ButtonProps>((props, ref) => {
   // @ts-ignore
@@ -46,7 +40,7 @@ const CreateButton = forwardRef<any, ButtonProps>((props, ref) => {
 interface Props {
   object: ObjectStore.ObjectResponse;
   open: boolean;
-  onClose: () => void;
+  onClose: (password?: string) => void;
   onDone: () => void;
 }
 
@@ -67,6 +61,7 @@ const CreateShareModal: FC<Props> = ({ object, open, onClose, onDone }) => {
     shareType,
     loading,
     sent,
+    password,
     setLoading,
     setSent,
     setErrors,
@@ -127,8 +122,9 @@ const CreateShareModal: FC<Props> = ({ object, open, onClose, onDone }) => {
   }, [isLarge, open]);
 
   const handleClose = () => {
+    const sharePassword = password;
     resetContext();
-    onClose();
+    onClose(sharePassword);
   };
 
   const handleCreateShare = async (

--- a/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/CreateSharesButton/index.tsx
+++ b/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/CreateSharesButton/index.tsx
@@ -1,16 +1,17 @@
 import { Box, Button, ButtonProps } from "@mui/material";
-import { FC, useState } from "react";
+import { FC, useEffect, useState } from "react";
 
 import AddIcon from "@mui/icons-material/Add";
 import { ObjectStore } from "../../../types";
 import { ShareCreateProvider } from "../../../hooks/context";
 import CreateShareModal from "./CreateShareModal";
+import CopyPasswordModal from "./CopyPasswordModal";
 
 interface Props {
   object: ObjectStore.ObjectResponse;
   shareType?: string; // email | link
   ButtonProps?: ButtonProps;
-  onClose: () => void;
+  onClose: (password?: string) => void;
   onDone: () => void;
 }
 
@@ -22,9 +23,18 @@ const CreateSharesButton: FC<Props> = ({
   onDone,
 }) => {
   const [open, setOpen] = useState(false);
-  const handleClose = () => {
+  const [password, setPassword] = useState("");
+
+  const handleClose = (password?: string) => {
     setOpen(false);
+    if (!!password) {
+      setPassword(password);
+    }
     onClose();
+  };
+
+  const handlePasswordClose = () => {
+    setPassword("");
   };
 
   return (
@@ -47,6 +57,11 @@ const CreateSharesButton: FC<Props> = ({
           open={open}
           onClose={handleClose}
           onDone={onDone}
+        />
+        <CopyPasswordModal
+          password={password}
+          open={!!password}
+          onClose={handlePasswordClose}
         />
       </ShareCreateProvider>
     </>

--- a/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/GetEmailLinkField.tsx
+++ b/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/GetEmailLinkField.tsx
@@ -51,7 +51,7 @@ const UnControlledGetEmailLinkField: FC<FieldComponentProps> = ({
   return (
     <Stack gap={1} width="100%">
       <Typography variant="caption" color="textSecondary" mt={1}>
-        Enter an email to recieve the authentication code
+        Enter an email to protect the link with a one-time authentication code
       </Typography>
       <Stack width="100%" direction="row" spacing={1}>
         <TextField

--- a/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/GetPasswordLinkField.tsx
+++ b/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/GetPasswordLinkField.tsx
@@ -54,7 +54,7 @@ const UnControlledGetPasswordLinkField: FC<FieldComponentProps> = ({
   return (
     <Stack gap={1} width="100%">
       <Typography variant="caption" color="textSecondary" mt={1}>
-        Enter an password to recieve the authentication code
+        Enter a password to protect access to the link
       </Typography>
       <Stack
         width="100%"

--- a/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/GetPhoneLinkField.tsx
+++ b/packages/react-mui-store-file-viewer/src/components/CreateNewShareButton/GetPhoneLinkField.tsx
@@ -56,7 +56,8 @@ const UnControlledGetPhoneLinkField: FC<FieldComponentProps> = ({
   return (
     <Stack gap={1} width="100%">
       <Typography variant="caption" color="textSecondary" mt={1}>
-        Enter a phone number to recieve the authentication code
+        Enter a phone number to protect the link with a one-time authentication
+        code
       </Typography>
       <Stack width="100%" direction="row" spacing={1}>
         <TextField


### PR DESCRIPTION
- Show copy password after Share via Email password share create
- Correct text above password input for Get Link

Update text on one-time auth login screens.