### PR TITLE
pangea-node-sdk: correct redaction method overrides, add examples

### DIFF
--- a/examples/redact/README.md
+++ b/examples/redact/README.md
@@ -2,7 +2,7 @@
 
 ## Setup
 
-Set up environment variables ([Instructions](https://pangea.cloud/docs/getting-started/integrate/#set-environment-variables)) `PANGEA_REDACT_TOKEN` and `PANGEA_DOMAIN` with your project token configured on Pangea User Console (token should have access to Redact service [Instructions](https://pangea.cloud/docs/getting-started/configure-services/#configure-a-pangea-service)) and with your Pangea domain.
+Set up the environment variables ([Instructions](https://pangea.cloud/docs/redact#set-your-environment-variables)) `PANGEA_REDACT_TOKEN` and `PANGEA_DOMAIN` with your project token configured on the Pangea User Console (token should have access to Redact service [Instructions](https://pangea.cloud/docs/admin-guide/tokens)) and with your Pangea domain.
 
 ## Run example
 

--- a/examples/redact/package.json
+++ b/examples/redact/package.json
@@ -1,15 +1,12 @@
 {
   "name": "redact_examples",
-  "version": "2.0.0",
-  "description": "Pangea Redact text example",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
+  "version": "0.0.0-development",
+  "description": "Pangea Redact examples",
+  "private": true,
   "author": "Pangea",
   "license": "MIT",
   "packageManager": "yarn@1.22.22",
   "dependencies": {
-    "pangea-node-sdk": "4.4.0"
+    "pangea-node-sdk": "file:../../packages/pangea-node-sdk"
   }
 }

--- a/examples/redact/redact_structured.mjs
+++ b/examples/redact/redact_structured.mjs
@@ -1,0 +1,24 @@
+/* eslint-disable no-console */
+
+import process from "node:process";
+
+import { PangeaConfig, RedactService } from "pangea-node-sdk";
+
+const token = process.env.PANGEA_REDACT_TOKEN;
+const config = new PangeaConfig({ domain: process.env.PANGEA_DOMAIN });
+
+const redact = new RedactService(token, config);
+
+(async () => {
+  const data = {
+    phone: "415-867-5309",
+    name: "Jenny Jenny",
+  };
+
+  console.log("Redacting PII from: %s", JSON.stringify(data));
+  const response = await redact.redactStructured(data);
+  console.log(
+    "Redacted data: %s",
+    JSON.stringify(response.result.redacted_data)
+  );
+})();

--- a/examples/redact/text_llm_request.mjs
+++ b/examples/redact/text_llm_request.mjs
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+
+import process from "node:process";
+
+import { PangeaConfig, RedactService } from "pangea-node-sdk";
+
+const token = process.env.PANGEA_REDACT_TOKEN;
+const config = new PangeaConfig({ domain: process.env.PANGEA_DOMAIN });
+
+const redact = new RedactService(token, config);
+
+(async () => {
+  const text = "Visit our website at https://pangea.cloud";
+  console.log("Redacting PII from: %s", text);
+  const redacted = await redact.redact(text, { llm_request: true });
+  console.log("Redacted text: %s", redacted.result.redacted_text);
+
+  const unredacted = await redact.unredact({
+    redacted_data: redacted.result.redacted_text,
+    fpe_context: redacted.result.fpe_context,
+  });
+  console.log("Unredacted text: %s", unredacted.result.data);
+})();

--- a/examples/redact/unredact.mjs
+++ b/examples/redact/unredact.mjs
@@ -1,0 +1,30 @@
+/* eslint-disable no-console */
+
+import process from "node:process";
+
+import { PangeaConfig, RedactService } from "pangea-node-sdk";
+
+const token = process.env.PANGEA_REDACT_TOKEN;
+const config = new PangeaConfig({ domain: process.env.PANGEA_DOMAIN });
+
+const redact = new RedactService(token, config);
+
+(async () => {
+  const text = "Hello, my phone number is 123-456-7890";
+  console.log("Redacting PII from: %s", text);
+  const redacted = await redact.redact(text, {
+    redaction_method_overrides: {
+      PHONE_NUMBER: {
+        redaction_type: "fpe",
+        fpe_alphabet: "numeric",
+      },
+    },
+  });
+  console.log("Redacted text: %s", redacted.result.redacted_text);
+
+  const unredacted = await redact.unredact({
+    redacted_data: redacted.result.redacted_text,
+    fpe_context: redacted.result.fpe_context,
+  });
+  console.log("Unredacted text: %s", unredacted.result.data);
+})();

--- a/examples/redact/yarn.lock
+++ b/examples/redact/yarn.lock
@@ -95,10 +95,8 @@ merkle-tools@^1.4.1:
   dependencies:
     js-sha3 "^0.8.0"
 
-pangea-node-sdk@4.4.0:
+"pangea-node-sdk@file:../../packages/pangea-node-sdk":
   version "4.4.0"
-  resolved "https://registry.yarnpkg.com/pangea-node-sdk/-/pangea-node-sdk-4.4.0.tgz#064ce7dda3b4bac352e1e686a32c46c9de669cd7"
-  integrity sha512-MLBsKZkHvn7pWBFHrdqxYguKXW6zMuSe/B8D2yL5mnA0LsMBvuow1QMNSIZh5h7TJZuaICgVTQH9l7sfX/pm0g==
   dependencies:
     "@aws-crypto/crc32c" "^5.2.0"
     crypto-js "^4.2.0"

--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Redact: corrected `redaction_method_overrides` types.
+
 ### Removed
 
 - AI Guard: `llm_info` and `llm_input`.


### PR DESCRIPTION
The typing around `redaction_method_overrides` was slightly wrong; the field accepts a object where the keys are the rule name and the values are the overrides. I fixed that and also made the typing stricter so that things like e.g. `fpe_alphabet` can only be specified if `redaction_type: "fpe"`.