### PR TITLE
pangea-node-sdk: add Management and Config APIs

### DIFF
--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Guard: detector overrides.
 - AI Guard: topic detector.
 - AI Guard: `ignore_recipe` in detector overrides.
+- Management: new API client.
+- Redact: config APIs.
+- Secure Audit Log: config APIs.
 
 ### Changed
 

--- a/packages/pangea-node-sdk/package.json
+++ b/packages/pangea-node-sdk/package.json
@@ -32,6 +32,7 @@
     "formdata-node": "^6.0.3",
     "json-canon": "^1.0.1",
     "merkle-tools": "^1.4.1",
+    "neoqs": "^6.13.0",
     "promise-retry": "^2.0.1"
   },
   "devDependencies": {

--- a/packages/pangea-node-sdk/src/services/audit.ts
+++ b/packages/pangea-node-sdk/src/services/audit.ts
@@ -514,6 +514,147 @@ class AuditService extends BaseService {
     return this.post("v1/download_results", request);
   }
 
+  /**
+   * @summary Get a service config.
+   * @description Get a service config.
+   * @operationId audit_post_v1beta_config
+   * @param configId The config ID
+   */
+  async getServiceConfig(
+    configId: string
+  ): Promise<PangeaResponse<Audit.ServiceConfig>> {
+    return await this.post("v1beta/config", { config_id: configId });
+  }
+
+  /**
+   * @summary Create a service config
+   * @description Create a service config with the specified version and parameters
+   * @operationId audit_post_v1beta_config_create
+   * @param version The version of the service config to create (1, 2, or 3)
+   * @param name Configuration name
+   * @param options Configuration options
+   */
+  async createServiceConfig(
+    version: 1 | 2 | 3,
+    name: string,
+    options: {
+      /** Retention window for cold query result / state information. */
+      cold_query_result_retention?: string;
+      /** Retention window for logs in cold storage. Deleted afterwards. */
+      cold_storage?: string;
+      /** Configuration for forwarding audit logs to external systems. */
+      forwarding_configuration?: Audit.ForwardingConfiguration;
+      /** Retention window to keep audit logs in hot storage. */
+      hot_storage?: string;
+      /** Length of time to preserve server-side query result caching. */
+      query_result_retention?: string;
+      /** A redact service config that will be used to redact PII from logs. */
+      redact_service_config_id?: string;
+      /** Fields to perform redaction against. */
+      redaction_fields?: string[];
+      /** Retention window to store audit logs. */
+      retention?: string;
+      /** Audit log field configuration. Only settable at create time. */
+      schema?: Audit.Schema;
+      /** ID of the Vault key used for signing. If missing, use a default Audit key. */
+      vault_key_id?: string;
+      /** A vault service config that will be used to sign logs. */
+      vault_service_config_id?: string;
+      /** Enable/disable event signing. */
+      vault_sign?: boolean;
+      /** Retention window for logs in warm storage. Migrated to cold or deleted afterwards. */
+      warm_storage?: string;
+    } = {}
+  ): Promise<PangeaResponse<Audit.ServiceConfig>> {
+    return await this.post("v1beta/config/create", {
+      version,
+      name,
+      ...options,
+    });
+  }
+
+  /**
+   * @summary Update a service config
+   * @description Update an existing service config with new parameters
+   * @operationId audit_post_v1beta_config_update
+   * @param id The config ID
+   * @param name Configuration name
+   * @param updated_at The DB timestamp when this config was last updated at
+   * @param options Configuration options to update
+   */
+  async updateServiceConfig(
+    id: string,
+    name: string,
+    updated_at: Date,
+    options: {
+      /** Retention window for cold query result / state information. */
+      cold_query_result_retention?: string;
+      /** Retention window for logs in cold storage. Deleted afterwards. */
+      cold_storage?: string;
+      /** Configuration for forwarding audit logs to external systems. */
+      forwarding_configuration?: Audit.ForwardingConfiguration;
+      /** Retention window to keep audit logs in hot storage. */
+      hot_storage?: string;
+      /** Length of time to preserve server-side query result caching. */
+      query_result_retention?: string;
+      /** A redact service config that will be used to redact PII from logs. */
+      redact_service_config_id?: string;
+      /** Retention window to store audit logs. */
+      retention?: string;
+      /** Audit log field configuration. */
+      schema?: Audit.Schema;
+      /** ID of the Vault key used for signing. If missing, use a default Audit key. */
+      vault_key_id?: string;
+      /** A vault service config that will be used to sign logs. */
+      vault_service_config_id?: string;
+      /** Enable/disable event signing. */
+      vault_sign?: boolean;
+      /** Retention window for logs in warm storage. Migrated to cold or deleted afterwards. */
+      warm_storage?: string;
+    } = {}
+  ): Promise<PangeaResponse<Audit.ServiceConfig>> {
+    return await this.post("v1beta/config/update", {
+      id,
+      name,
+      updated_at,
+      ...options,
+    });
+  }
+
+  /**
+   * @summary Delete a service config
+   * @description Delete an existing service config
+   * @operationId audit_post_v1beta_config_delete
+   * @param id The config ID
+   */
+  async deleteServiceConfig(
+    id: string
+  ): Promise<PangeaResponse<Audit.ServiceConfig>> {
+    return await this.post("v1beta/config/delete", { id });
+  }
+
+  /**
+   * @summary List service configs
+   * @description List existing service configs with optional filtering and pagination
+   * @operationId audit_post_v1beta_config_list
+   */
+  async listServiceConfigs(
+    options: {
+      /** Filter criteria for the list */
+      filter?: Audit.ServiceConfigFilter;
+      /** Reflected value from a previous response to obtain the next page of results */
+      last?: string;
+      /** Order results asc(ending) or desc(ending) */
+      order?: "asc" | "desc";
+      /** Which field to order results by */
+      order_by?: "id" | "created_at" | "updated_at";
+      /** Maximum results to include in the response */
+      size?: number;
+    } = {}
+  ): Promise<PangeaResponse<Audit.ServiceConfigListResult>> {
+    return await this.post("v1beta/config/list", options);
+  }
+
   async processSearchResponse(
     response: PangeaResponse<Audit.SearchResponse>,
     options: Audit.SearchOptions

--- a/packages/pangea-node-sdk/src/services/base.ts
+++ b/packages/pangea-node-sdk/src/services/base.ts
@@ -77,7 +77,10 @@ class BaseService {
     data: object,
     options: PostOptions = {}
   ): Promise<PangeaResponse<R>> {
-    return await this.request.post(endpoint, data, options);
+    return await this.request.post(endpoint, data, {
+      ...options,
+      pangeaResponse: true,
+    });
   }
 
   async downloadFile(url: string): Promise<AttachedFile> {

--- a/packages/pangea-node-sdk/src/services/management.ts
+++ b/packages/pangea-node-sdk/src/services/management.ts
@@ -1,0 +1,507 @@
+import { Management } from "@src/types.js";
+import PangeaConfig from "../config.js";
+import PangeaResponse from "../response.js";
+import BaseService from "./base.js";
+
+class Authorization extends BaseService {
+  constructor(token: string, config: PangeaConfig) {
+    super("authorization.access", token, config);
+  }
+}
+
+class Console extends BaseService {
+  constructor(token: string, config: PangeaConfig) {
+    super("api.console", token, config);
+  }
+}
+
+/** Management API client. */
+export class ManagementService {
+  private authorization: Authorization;
+  private console: Console;
+
+  /**
+   * Creates a new `ManagementService` with the given Pangea API token and
+   * configuration.
+   *
+   * @param token Pangea API token.
+   * @param config Configuration.
+   *
+   * @example
+   * ```js
+   * const config = new PangeaConfig({ domain: "pangea_domain" });
+   * const management = new ManagementService("pangea_token", config);
+   * ```
+   *
+   * @summary Management
+   */
+  constructor(token: string, config: PangeaConfig) {
+    this.authorization = new Authorization(token, config);
+    this.console = new Console(token, config);
+  }
+
+  /**
+   * @summary Retrieve an organization
+   * @description Retrieve an organization
+   * @operationId api.console_post_v1beta_platform_org_get
+   * @param orgId An Organization Pangea ID
+   */
+  async getOrg(
+    orgId: string
+  ): Promise<PangeaResponse<Management.Organization>> {
+    return await this.console.request.post("v1beta/platform/org/get", {
+      id: orgId,
+    } as object);
+  }
+
+  /**
+   * @summary Update an organization
+   * @description Update an organization
+   * @operationId api.console_post_v1beta_platform_org_update
+   * @param orgId An Organization Pangea ID
+   * @param name The new name for the organization
+   */
+  async updateOrg(
+    orgId: string,
+    name: string
+  ): Promise<PangeaResponse<Management.Organization>> {
+    return await this.console.request.post("v1beta/platform/org/update", {
+      id: orgId,
+      name: name,
+    } as object);
+  }
+
+  /**
+   * @summary Retrieve a project
+   * @description Retrieve a project
+   * @operationId api.console_post_v1beta_platform_project_get
+   * @param projectId A Project Pangea ID
+   */
+  async getProject(
+    projectId: string
+  ): Promise<PangeaResponse<Management.Project>> {
+    return await this.console.request.post("v1beta/platform/project/get", {
+      id: projectId,
+    } as object);
+  }
+
+  /**
+   * @summary List projects
+   * @description List projects
+   * @operationId api.console_post_v1beta_platform_project_list
+   * @param orgId An Organization Pangea ID
+   * @param filter Optional filter criteria
+   * @param offset Optional offset for pagination
+   * @param limit Optional limit for pagination
+   */
+  async listProjects(
+    orgId: string,
+    options: {
+      filter?: Management.ListProjectsFilter;
+      offset?: number;
+      limit?: number;
+    } = {}
+  ): Promise<PangeaResponse<Management.ListProjectsResult>> {
+    return await this.console.request.post("v1beta/platform/project/list", {
+      org_id: orgId,
+      ...options,
+    } as object);
+  }
+
+  /**
+   * @summary Create a project
+   * @description Create a project
+   * @operationId api.console_post_v1beta_platform_project_create
+   * @param request.org_id An Organization Pangea ID
+   * @param request.name The name of the project
+   * @param request.geo The geographical region for the project
+   * @param request.region Optional region for the project
+   */
+  async createProject(request: {
+    org_id: string;
+    name: string;
+    geo: "us" | "eu";
+    region?: "us-west-1" | "us-east-1" | "eu-central-1";
+  }): Promise<PangeaResponse<Management.Project>> {
+    return await this.console.request.post(
+      "v1beta/platform/project/create",
+      request
+    );
+  }
+
+  /**
+   * @summary Update a project
+   * @description Update a project
+   * @operationId api.console_post_v1beta_platform_project_update
+   * @param projectId A Project Pangea ID
+   * @param name The new name for the project
+   */
+  async updateProject(
+    projectId: string,
+    name: string
+  ): Promise<PangeaResponse<Management.Project>> {
+    return await this.console.request.post("v1beta/platform/project/update", {
+      id: projectId,
+      name,
+    } as object);
+  }
+
+  /**
+   * @summary Delete a project
+   * @description Delete a project
+   * @operationId api.console_post_v1beta_platform_project_delete
+   * @param projectId A Project Pangea ID
+   */
+  async deleteProject(
+    projectId: string
+  ): Promise<PangeaResponse<Management.Project>> {
+    return await this.console.request.post("v1beta/platform/project/delete", {
+      id: projectId,
+    } as object);
+  }
+
+  /**
+   * @summary Create Platform Client
+   * @description Create Platform Client
+   * @operationId createPlatformClient
+   * @param request.scope A list of space separated scope
+   * @param request.token_endpoint_auth_method The authentication method for the token endpoint.
+   * @param request.redirect_uris A list of allowed redirect URIs for the client.
+   * @param request.grant_types A list of OAuth grant types that the client can use.
+   * @param request.response_types A list of OAuth response types that the client can use.
+   * @param request.client_secret_expires_in A positive time duration in seconds or null
+   * @param request.client_token_expires_in A positive time duration in seconds or null
+   * @param request.roles A list of roles
+   */
+  async createClient(request: {
+    client_name: string;
+    scope: string;
+    token_endpoint_auth_method?: Management.AccessClientTokenAuth;
+    redirect_uris?: string[];
+    grant_types?: string[];
+    response_types?: (string | null)[];
+    client_secret_expires_in?: number;
+    client_token_expires_in?: number;
+    client_secret_name?: string;
+    client_secret_description?: string;
+    roles?: Management.AccessRole[];
+  }): Promise<Management.AccessClientCreateInfo> {
+    return await this.authorization.request.post(
+      "v1beta/oauth/clients/register",
+      request,
+      { pangeaResponse: false }
+    );
+  }
+
+  /**
+   * @summary List platform clients
+   * @description List platform clients
+   * @operationId listPlatformClients
+   * @param options.created_at Only records where created_at equals this value
+   * @param options.created_at__gt Only records where created_at is greater than this value
+   * @param options.created_at__gte Only records where created_at is greater than or equal to this value
+   * @param options.created_at__lt Only records where created_at is less than this value
+   * @param options.created_at__lte Only records where created_at is less than or equal to this value
+   * @param options.client_id Only records where id equals this value
+   * @param options.client_id__contains Only records where id includes each substring
+   * @param options.client_id__in Only records where id equals one of the provided substrings
+   * @param options.client_name Only records where name equals this value
+   * @param options.client_name__contains Only records where name includes each substring
+   * @param options.client_name__in Only records where name equals one of the provided substrings
+   * @param options.scopes A list of tags that all must be present
+   * @param options.updated_at Only records where updated_at equals this value
+   * @param options.updated_at__gt Only records where updated_at is greater than this value
+   * @param options.updated_at__gte Only records where updated_at is greater than or equal to this value
+   * @param options.updated_at__lt Only records where updated_at is less than this value
+   * @param options.updated_at__lte Only records where updated_at is less than or equal to this value
+   * @param options.last Reflected value from a previous response to obtain the next page of results
+   * @param options.order Order results asc(ending) or desc(ending)
+   * @param options.order_by Which field to order results by
+   * @param options.size Maximum results to include in the response
+   */
+  async listClients(
+    options: {
+      created_at?: string;
+      created_at__gt?: string;
+      created_at__gte?: string;
+      created_at__lt?: string;
+      created_at__lte?: string;
+      client_id?: string;
+      client_id__contains?: string[];
+      client_id__in?: string[];
+      client_name?: string;
+      client_name__contains?: string[];
+      client_name__in?: string[];
+      scopes?: string[];
+      updated_at?: string;
+      updated_at__gt?: string;
+      updated_at__gte?: string;
+      updated_at__lt?: string;
+      updated_at__lte?: string;
+      last?: string;
+      order?: "asc" | "desc";
+      order_by?: "id" | "created_at" | "updated_at" | "name" | "token_type";
+      size?: number;
+    } = {}
+  ): Promise<Management.AccessClientListResult> {
+    return await this.authorization.request.get<Management.AccessClientListResult>(
+      "v1beta/oauth/clients",
+      {
+        query: { ...options },
+        pangeaResponse: false,
+      }
+    );
+  }
+
+  /**
+   * @summary Get a platform client
+   * @description Get a platform client
+   * @operationId getPlatformClient
+   */
+  async getClient(clientId: string): Promise<Management.AccessClientInfo> {
+    return await this.authorization.request.get<Management.AccessClientInfo>(
+      `v1beta/oauth/clients/${clientId}`,
+      {
+        pangeaResponse: false,
+      }
+    );
+  }
+
+  /**
+   * @summary Update platform client's scope
+   * @description Update platform client's scope
+   * @operationId updatePlatformClient
+   */
+  async updateClient(request: {
+    client_id: string;
+    options: {
+      scope: string;
+      token_endpoint_auth_method?: Management.AccessClientTokenAuth;
+      redirect_uris?: string[];
+      response_types?: (string | null)[];
+      grant_types?: string[];
+    };
+  }): Promise<Management.AccessClientInfo>;
+
+  /**
+   * @summary Update platform client's name
+   * @description Update platform client's name
+   * @operationId updatePlatformClient
+   */
+  async updateClient(request: {
+    client_id: string;
+    options: {
+      client_name: string;
+      token_endpoint_auth_method?: Management.AccessClientTokenAuth;
+      redirect_uris?: string[];
+      response_types?: (string | null)[];
+      grant_types?: string[];
+    };
+  }): Promise<Management.AccessClientInfo>;
+
+  /**
+   * @summary Update platform client's scope
+   * @description Update platform client's scope
+   * @operationId updatePlatformClient
+   */
+  async updateClient(request: {
+    client_id: string;
+    options: {
+      scope?: string;
+      client_name?: string;
+      token_endpoint_auth_method?: Management.AccessClientTokenAuth;
+      redirect_uris?: string[];
+      response_types?: (string | null)[];
+      grant_types?: string[];
+    };
+  }): Promise<Management.AccessClientInfo> {
+    return await this.authorization.request.post<Management.AccessClientInfo>(
+      `v1beta/oauth/clients/${request.client_id}`,
+      request.options,
+      { pangeaResponse: false }
+    );
+  }
+
+  /**
+   * @summary Delete platform client
+   * @description Delete platform client
+   * @operationId deletePlatformClient
+   * @param clientId The client ID to delete
+   */
+  async deleteClient(clientId: string): Promise<void> {
+    await this.authorization.request.delete(`v1beta/oauth/clients/${clientId}`);
+  }
+
+  /**
+   * @summary Create client secret
+   * @description Create client secret
+   * @operationId createClientSecret
+   * @param request.client_secret_expires_in A positive time duration in seconds
+   */
+  async createClientSecret(request: {
+    client_id: string;
+    client_secret_id: string;
+    client_secret_expires_in?: number;
+    client_secret_name?: string;
+    client_secret_description?: string;
+  }): Promise<Management.AccessClientSecretInfo> {
+    return await this.authorization.request.post(
+      `v1beta/oauth/clients/${request.client_id}/secrets`,
+      request,
+      { pangeaResponse: false }
+    );
+  }
+
+  /**
+   * @summary List client secret metadata
+   * @description List client secret metadata
+   * @operationId listClientSecretMetadata
+   * @param request.id The client ID to list secrets for
+   * @param request.created_at Only records where created_at equals this value
+   * @param request.created_at__gt Only records where created_at is greater than this value
+   * @param request.created_at__gte Only records where created_at is greater than or equal to this value
+   * @param request.created_at__lt Only records where created_at is less than this value
+   * @param request.created_at__lte Only records where created_at is less than or equal to this value
+   * @param request.client_secret_name Only records where name equals this value
+   * @param request.client_secret_name__contains Only records where name includes each substring
+   * @param request.client_secret_name__in Only records where name equals one of the provided substrings
+   * @param request.last Reflected value from a previous response to obtain the next page of results
+   * @param request.order Order results asc(ending) or desc(ending)
+   * @param request.order_by Which field to order results by
+   * @param request.size Maximum results to include in the response
+   */
+  async listClientSecretMetadata(request: {
+    id: string;
+    created_at?: string;
+    created_at__gt?: string;
+    created_at__gte?: string;
+    created_at__lt?: string;
+    created_at__lte?: string;
+    client_secret_name?: string;
+    client_secret_name__contains?: string[];
+    client_secret_name__in?: string[];
+    last?: string;
+    order?: "asc" | "desc";
+    order_by?: "id" | "created_at" | "updated_at" | "client_secret_id";
+    size?: number;
+  }): Promise<Management.AccessClientSecretInfoListResult> {
+    const { id, ...params } = request;
+    return await this.authorization.request.get<Management.AccessClientSecretInfoListResult>(
+      `v1beta/oauth/clients/${id}/secrets/metadata`,
+      {
+        query: params,
+        pangeaResponse: false,
+      }
+    );
+  }
+
+  /**
+   * @summary Revoke client secret
+   * @description Revoke client secret
+   * @operationId revokeClientSecret
+   * @param request.id The client ID
+   * @param request.client_secret_id The client secret ID to revoke
+   */
+  async revokeClientSecret(request: {
+    id: string;
+    client_secret_id: string;
+  }): Promise<void> {
+    await this.authorization.request.delete(
+      `v1beta/oauth/clients/${request.id}/secrets/${request.client_secret_id}`
+    );
+  }
+
+  /**
+   * @summary Update client secret
+   * @description Update client secret
+   * @operationId updateClientSecret
+   * @param request.id The client ID
+   * @param request.client_secret_id The client secret ID to update
+   * @param request.client_secret_expires_in A positive time duration in seconds
+   * @param request.client_secret_name The new name for the client secret
+   * @param request.client_secret_description The new description for the client secret
+   */
+  async updateClientSecret(request: {
+    id: string;
+    client_secret_id: string;
+    client_secret_expires_in?: number;
+    client_secret_name?: string;
+    client_secret_description?: string;
+  }): Promise<Management.AccessClientSecretInfo> {
+    const { id, client_secret_id, ...data } = request;
+    return await this.authorization.request.post<Management.AccessClientSecretInfo>(
+      `v1beta/oauth/clients/${id}/secrets/${client_secret_id}`,
+      data,
+      { pangeaResponse: false }
+    );
+  }
+
+  /**
+   * @summary List client roles
+   * @description List client roles
+   * @operationId listClientRoles
+   * @param request.id The client ID
+   * @param request.resource_type Filter by resource type
+   * @param request.resource_id Filter by resource ID
+   * @param request.role Filter by role
+   */
+  async listClientRoles(request: {
+    id: string;
+    resource_type?: string;
+    resource_id?: string;
+    role?: string;
+  }): Promise<Management.AccessRolesListResult> {
+    const { id, ...params } = request;
+    return await this.authorization.request.get<Management.AccessRolesListResult>(
+      `v1beta/oauth/clients/${id}/roles`,
+      {
+        query: params,
+        pangeaResponse: false,
+      }
+    );
+  }
+
+  /**
+   * @summary Grant client access
+   * @description Grant client access
+   * @operationId grantClientRoles
+   * @param request.id The client ID
+   * @param request.roles A list of roles
+   * @param request.scope A list of space separated scope
+   */
+  async grantClientAccess(request: {
+    id: string;
+    roles: Management.AccessRole[];
+    scope: string;
+  }): Promise<void> {
+    const { id, ...data } = request;
+    await this.authorization.request.post(
+      `v1beta/oauth/clients/${id}/grant`,
+      data,
+      { pangeaResponse: false }
+    );
+  }
+
+  /**
+   * @summary Revoke client access
+   * @description Revoke client access
+   * @operationId revokeClientRoles
+   * @param request.id The client ID
+   * @param request.roles A list of roles
+   * @param request.scope A list of space separated scope
+   */
+  async revokeClientAccess(request: {
+    id: string;
+    roles: Management.AccessRole[];
+    scope: string;
+  }): Promise<void> {
+    const { id, ...data } = request;
+    await this.authorization.request.post(
+      `v1beta/oauth/clients/${id}/revoke`,
+      data,
+      { pangeaResponse: false }
+    );
+  }
+}
+
+export default ManagementService;

--- a/packages/pangea-node-sdk/src/services/redact.ts
+++ b/packages/pangea-node-sdk/src/services/redact.ts
@@ -116,6 +116,212 @@ class RedactService extends BaseService {
   ): Promise<PangeaResponse<Redact.UnredactResult<O>>> {
     return this.post("v1/unredact", request);
   }
+
+  /**
+   * @summary Get a service config.
+   * @description Get a service config.
+   * @operationId redact_post_v1beta_config
+   * @param configId Configuration ID.
+   */
+  async getServiceConfig(
+    configId: string
+  ): Promise<PangeaResponse<Redact.ServiceConfigResult>> {
+    return await this.post("v1beta/config", { id: configId });
+  }
+
+  /**
+   * @summary Create a v1.0.0 service config
+   * @description Create a v1.0.0 service config
+   * @operationId redact_post_v1beta_config_create
+   * @param options.vault_service_config_id Service config used to create the secret
+   * @param options.salt_vault_secret_id Pangea only allows hashing to be done using a salt value to prevent brute-force attacks
+   */
+  createServiceConfig(
+    name: string,
+    options: {
+      version?: "1.0.0";
+      enabled_rules?: string[];
+      redactions?: { [key: string]: Redact.Redaction };
+      vault_service_config_id?: string;
+      salt_vault_secret_id?: string;
+      fpe_vault_secret_id?: string;
+      rules?: { [key: string]: Redact.RuleV1 };
+      rulesets?: { [key: string]: Redact.RulesetV1 };
+      supported_languages?: "en"[];
+    }
+  ): Promise<PangeaResponse<Redact.ServiceConfigV1>>;
+
+  /**
+   * @summary Create a v2.0.0 service config
+   * @description Create a v2.0.0 service config
+   * @operationId redact_post_v1beta_config_create
+   * @param options.enforce_enabled_rules Always run service config enabled rules across all redact calls regardless of flags?
+   * @param options.vault_service_config_id Service config used to create the secret
+   * @param options.salt_vault_secret_id Pangea only allows hashing to be done using a salt value to prevent brute-force attacks
+   * @param options.fpe_vault_secret_id The ID of the key used by FF3 Encryption algorithms for FPE
+   */
+  createServiceConfig(
+    name: string,
+    options: {
+      version?: "2.0.0";
+      enabled_rules?: string[];
+      enforce_enabled_rules?: boolean;
+      redactions?: { [key: string]: Redact.Redaction };
+      vault_service_config_id?: string;
+      salt_vault_secret_id?: string;
+      fpe_vault_secret_id?: string;
+      rules?: { [key: string]: Redact.RuleV2 };
+      rulesets?: { [key: string]: Redact.RulesetV2 };
+      supported_languages?: "en"[];
+    }
+  ): Promise<PangeaResponse<Redact.ServiceConfigV2>>;
+
+  /**
+   * @summary Create a service config
+   * @description Create a service config with the specified version and parameters
+   * @operationId redact_post_v1beta_config_create
+   * @param name Configuration name
+   * @param options Configuration options
+   */
+  async createServiceConfig(
+    name: string,
+    options: {
+      version?: "1.0.0" | "2.0.0";
+      enabled_rules?: string[];
+      enforce_enabled_rules?: boolean;
+      redactions?: { [key: string]: Redact.Redaction };
+      vault_service_config_id?: string;
+      salt_vault_secret_id?: string;
+      fpe_vault_secret_id?: string;
+      rules?:
+        | { [key: string]: Redact.RuleV1 }
+        | { [key: string]: Redact.RuleV2 };
+      rulesets?:
+        | { [key: string]: Redact.RulesetV1 }
+        | { [key: string]: Redact.RulesetV2 };
+      supported_languages?: "en"[];
+    } = {}
+  ): Promise<PangeaResponse<Redact.ServiceConfigResult>> {
+    return await this.post("v1beta/config/create", { name, ...options });
+  }
+
+  /**
+   * @summary Update a v1.0.0 service config
+   * @description Update a v1.0.0 service config
+   * @operationId redact_post_v1beta_config_update
+   * @param options.vault_service_config_id Service config used to create the secret
+   * @param options.salt_vault_secret_id Pangea only allows hashing to be done using a salt value to prevent brute-force attacks
+   */
+  updateServiceConfig(
+    configId: string,
+    options: {
+      version?: "1.0.0";
+      name: string;
+      updated_at: string;
+      enabled_rules?: string[];
+      redactions?: { [key: string]: Redact.Redaction };
+      vault_service_config_id?: string;
+      salt_vault_secret_id?: string;
+      rules?: { [key: string]: Redact.RuleV1 };
+      rulesets?: { [key: string]: Redact.RulesetV1 };
+      supported_languages?: "en"[];
+    }
+  ): Promise<PangeaResponse<Redact.ServiceConfigV1>>;
+
+  /**
+   * @summary Update a v2.0.0 service config
+   * @description Update a v2.0.0 service config
+   * @operationId redact_post_v1beta_config_update
+   * @param options.enforce_enabled_rules Always run service config enabled rules across all redact calls regardless of flags?
+   * @param options.vault_service_config_id Service config used to create the secret
+   * @param options.salt_vault_secret_id Pangea only allows hashing to be done using a salt value to prevent brute-force attacks
+   * @param options.fpe_vault_secret_id The ID of the key used by FF3 Encryption algorithms for FPE
+   */
+  updateServiceConfig(
+    configId: string,
+    options: {
+      version?: "2.0.0";
+      name: string;
+      updated_at: string;
+      enabled_rules?: string[];
+      enforce_enabled_rules?: boolean;
+      redactions?: { [key: string]: Redact.Redaction };
+      vault_service_config_id?: string;
+      salt_vault_secret_id?: string;
+      fpe_vault_secret_id?: string;
+      rules?: { [key: string]: Redact.RuleV2 };
+      rulesets?: { [key: string]: Redact.RulesetV2 };
+      supported_languages?: "en"[];
+    }
+  ): Promise<PangeaResponse<Redact.ServiceConfigV2>>;
+
+  /**
+   * @summary Update a service config
+   * @description Update a service config with the specified version and parameters
+   * @operationId redact_post_v1beta_config_update
+   * @param configId The ID of the config to update
+   * @param options Configuration options
+   */
+  async updateServiceConfig(
+    configId: string,
+    options: {
+      version?: "1.0.0" | "2.0.0";
+      name: string;
+      updated_at: string;
+      enabled_rules?: string[];
+      enforce_enabled_rules?: boolean;
+      redactions?: { [key: string]: Redact.Redaction };
+      vault_service_config_id?: string;
+      salt_vault_secret_id?: string;
+      fpe_vault_secret_id?: string;
+      rules?:
+        | { [key: string]: Redact.RuleV1 }
+        | { [key: string]: Redact.RuleV2 };
+      rulesets?:
+        | { [key: string]: Redact.RulesetV1 }
+        | { [key: string]: Redact.RulesetV2 };
+      supported_languages?: "en"[];
+    }
+  ): Promise<PangeaResponse<Redact.ServiceConfigResult>> {
+    return await this.post("v1beta/config/update", {
+      id: configId,
+      ...options,
+    });
+  }
+
+  /**
+   * @summary Delete a service config
+   * @description Delete a service config
+   * @operationId redact_post_v1beta_config_delete
+   * @param configId An ID for a service config
+   */
+  async deleteServiceConfig(
+    configId: string
+  ): Promise<PangeaResponse<Redact.ServiceConfigResult>> {
+    return await this.post("v1beta/config/delete", { id: configId });
+  }
+
+  /**
+   * @summary List service configs
+   * @description List service configs
+   * @operationId redact_post_v1beta_config_list
+   * @param options.filter Filter criteria for the list
+   * @param options.last Reflected value from a previous response to obtain the next page of results
+   * @param options.order Order results asc(ending) or desc(ending)
+   * @param options.order_by Which field to order results by
+   * @param options.size Maximum results to include in the response
+   */
+  async listServiceConfigs(
+    options: {
+      filter?: Redact.ServiceConfigFilter;
+      last?: string;
+      order?: "asc" | "desc";
+      order_by?: "id" | "created_at" | "updated_at";
+      size?: number;
+    } = {}
+  ): Promise<PangeaResponse<Redact.ServiceConfigListResult>> {
+    return await this.post("v1beta/config/list", options);
+  }
 }
 
 export default RedactService;

--- a/packages/pangea-node-sdk/src/types.ts
+++ b/packages/pangea-node-sdk/src/types.ts
@@ -48,6 +48,9 @@ export type PangeaToken = string | ({ type: "pangea_token" } & Vault.GetResult);
 export interface PostOptions {
   pollResultSync?: boolean;
   files?: FileItems;
+
+  /** Whether or not the response body follows Pangea's standard response schema */
+  pangeaResponse?: boolean;
 }
 
 export enum ConfigEnv {
@@ -291,6 +294,274 @@ export namespace Audit {
      */
     verbose?: boolean;
   }
+
+  export type FieldType =
+    | "boolean"
+    | "datetime"
+    | "integer"
+    | "string"
+    | "string-unindexed"
+    | "text";
+
+  export interface SchemaField {
+    /** Prefix name / identity for the field. */
+    id: string;
+
+    /** The data type for the field. */
+    type: FieldType;
+
+    /** Human display description of the field. */
+    description?: string;
+
+    /** Human display name/title of the field. */
+    name?: string;
+
+    /** If true, redaction is performed against this field (if configured.) Only valid for string type. */
+    redact?: boolean;
+
+    /** If true, this field is required to exist in all logged events. */
+    required?: boolean;
+
+    /** The maximum size of the field. Only valid for strings, which limits number of UTF-8 characters. */
+    size?: number;
+
+    /** If true, this field is visible by default in audit UIs. */
+    ui_default_visible?: boolean;
+  }
+
+  export interface Schema {
+    /** If true, records contain fields to support client/vault signing. */
+    client_signable?: boolean;
+
+    /** Save (or reject) malformed AuditEvents. */
+    save_malformed?: string;
+
+    /** If true, records contain fields to support tamper-proofing. */
+    tamper_proofing?: boolean;
+
+    /** List of field definitions. */
+    fields?: SchemaField[];
+  }
+
+  export interface ForwardingConfiguration {
+    /** Type of forwarding configuration. */
+    type: string;
+
+    /** Whether forwarding is enabled. */
+    forwarding_enabled?: boolean;
+
+    /** URL where events will be written to. Must use HTTPS. */
+    event_url?: string;
+
+    /** If indexer acknowledgement is required, this must be provided along with a 'channel_id'. */
+    ack_url?: string;
+
+    /** An optional splunk channel included in each request if indexer acknowledgement is required. */
+    channel_id?: string;
+
+    /** Public certificate if a self signed TLS cert is being used. */
+    public_cert?: string;
+
+    /** Optional splunk index passed in the record bodies. */
+    index?: string;
+
+    /** The vault config used to store the HEC token. */
+    vault_config_id?: string;
+
+    /** The secret ID where the HEC token is stored in vault. */
+    vault_secret_id?: string;
+  }
+
+  export interface ServiceConfigV1 {
+    /** The config ID */
+    id?: string;
+
+    /** Version of the service config. */
+    version: 1;
+
+    /** The DB timestamp when this config was created. Ignored when submitted. */
+    created_at?: string;
+
+    /** The DB timestamp when this config was last updated at */
+    updated_at?: string;
+
+    /** Configuration name */
+    name?: string;
+
+    /** Retention window to store audit logs. */
+    retention?: string;
+
+    /** Retention window for cold query result / state information. */
+    cold_query_result_retention?: string;
+
+    /** Retention window to keep audit logs in hot storage. */
+    hot_storage?: string;
+
+    /** Length of time to preserve server-side query result caching. */
+    query_result_retention?: string;
+
+    /** A redact service config that will be used to redact PII from logs. */
+    redact_service_config_id?: string;
+
+    /** Fields to perform redaction against. */
+    redaction_fields?: string[];
+
+    /** A vault service config that will be used to sign logs. */
+    vault_service_config_id?: string;
+
+    /** ID of the Vault key used for signing. If missing, use a default Audit key */
+    vault_key_id?: string;
+
+    /** Enable/disable event signing */
+    vault_sign?: boolean;
+  }
+
+  export interface ServiceConfigV2 {
+    /** Audit log field configuration. Only settable at create time. */
+    audit_schema: Schema;
+
+    /** Version of the service config. */
+    version: 2;
+
+    /** Retention window for cold query result / state information. */
+    cold_query_result_retention?: string;
+
+    /** The DB timestamp when this config was created. Ignored when submitted. */
+    created_at?: string;
+
+    /** Retention window to keep audit logs in hot storage. */
+    hot_storage?: string;
+
+    /** The config ID */
+    id?: string;
+
+    /** Configuration name */
+    name?: string;
+
+    /** Length of time to preserve server-side query result caching. */
+    query_result_retention?: string;
+
+    /** A redact service config that will be used to redact PII from logs. */
+    redact_service_config_id?: string;
+
+    /** Retention window to store audit logs. */
+    retention?: string;
+
+    /** The DB timestamp when this config was last updated at */
+    updated_at?: string;
+
+    /** ID of the Vault key used for signing. If missing, use a default Audit key */
+    vault_key_id?: string;
+
+    /** A vault service config that will be used to sign logs. */
+    vault_service_config_id?: string;
+
+    /** Enable/disable event signing */
+    vault_sign?: boolean;
+
+    /** Configuration for forwarding audit logs to external systems. */
+    forwarding_configuration?: ForwardingConfiguration;
+  }
+
+  export interface ServiceConfigV3 {
+    /** Audit log field configuration. Only settable at create time. */
+    audit_schema: Schema;
+
+    /** Version of the service config. */
+    version: 3;
+
+    /** Retention window for logs in cold storage. Deleted afterwards. */
+    cold_storage?: string;
+
+    /** The DB timestamp when this config was created. Ignored when submitted. */
+    created_at?: string;
+
+    /** Configuration for forwarding audit logs to external systems. */
+    forwarding_configuration?: ForwardingConfiguration;
+
+    /** Retention window for logs in hot storage. Migrated to warm, cold, or deleted afterwards. */
+    hot_storage?: string;
+
+    /** The config ID */
+    id?: string;
+
+    /** Configuration name */
+    name?: string;
+
+    /** A redact service config that will be used to redact PII from logs. */
+    redact_service_config_id?: string;
+
+    /** The DB timestamp when this config was last updated at */
+    updated_at?: string;
+
+    /** ID of the Vault key used for signing. If missing, use a default Audit key */
+    vault_key_id?: string;
+
+    /** A vault service config that will be used to sign logs. */
+    vault_service_config_id?: string;
+
+    /** Enable/disable event signing */
+    vault_sign?: boolean;
+
+    /** Retention window for logs in warm storage. Migrated to cold or deleted afterwards. */
+    warm_storage?: string;
+  }
+
+  export type ServiceConfig =
+    | ServiceConfigV1
+    | ServiceConfigV2
+    | ServiceConfigV3;
+
+  export interface ServiceConfigFilter {
+    /** Only records where id equals this value. */
+    id?: string;
+
+    /** Only records where id includes each substring. */
+    id__contains?: string[];
+
+    /** Only records where id equals one of the provided substrings. */
+    id__in?: string[];
+
+    /** Only records where created_at equals this value. */
+    created_at?: string;
+
+    /** Only records where created_at is greater than this value. */
+    created_at__gt?: string;
+
+    /** Only records where created_at is greater than or equal to this value. */
+    created_at__gte?: string;
+
+    /** Only records where created_at is less than this value. */
+    created_at__lt?: string;
+
+    /** Only records where created_at is less than or equal to this value. */
+    created_at__lte?: string;
+
+    /** Only records where updated_at equals this value. */
+    updated_at?: string;
+
+    /** Only records where updated_at is greater than this value. */
+    updated_at__gt?: string;
+
+    /** Only records where updated_at is greater than or equal to this value. */
+    updated_at__gte?: string;
+
+    /** Only records where updated_at is less than this value. */
+    updated_at__lt?: string;
+
+    /** Only records where updated_at is less than or equal to this value. */
+    updated_at__lte?: string;
+  }
+
+  export interface ServiceConfigListResult {
+    /** The total number of service configs matched by the list request. */
+    count: number;
+
+    /** Used to fetch the next page of the current listing when provided in a repeated request's last parameter. */
+    last: string;
+
+    items: ServiceConfig[];
+  }
 }
 
 export namespace AIGuard {
@@ -523,6 +794,146 @@ export namespace AIGuard {
   }
 }
 
+export namespace Management {
+  export interface Organization {
+    id: string;
+    name: string;
+    owner: string;
+    owner_email?: string;
+    created_at: string;
+    updated_at: string;
+    csp: string;
+  }
+
+  export interface Project {
+    id: string;
+    name: string;
+    org: string;
+    created_at: string;
+    updated_at: string;
+    /** The geographical region for the project. */
+    geo: "us" | "eu";
+    /** The region for the project. */
+    region: "us-west-1" | "us-east-1" | "eu-central-1";
+  }
+
+  export interface ListProjectsFilter {
+    search?: string;
+    geo?: string;
+    region?: string;
+  }
+
+  export interface ListProjectsResult {
+    /** A list of projects */
+    results: Project[];
+    count: number;
+    offset?: number;
+  }
+
+  export type AccessClientTokenAuth =
+    | "client_secret_basic"
+    | "client_secret_post";
+
+  export interface AccessClientInfo {
+    /** An ID for a service account */
+    client_id: string;
+    /** A time in ISO-8601 format */
+    created_at: string;
+    /** A time in ISO-8601 format */
+    updated_at: string;
+    client_name: string;
+    /** A list of space separated scope */
+    scope: string;
+    /** The authentication method for the token endpoint. */
+    token_endpoint_auth_method: AccessClientTokenAuth;
+    /** A list of allowed redirect URIs for the client. */
+    redirect_uris: string[];
+    /** A list of OAuth grant types that the client can use. */
+    grant_types: string[];
+    /** A list of OAuth response types that the client can use. */
+    response_types: (string | null)[];
+    /** A positive time duration in seconds or null */
+    client_token_expires_in?: number | null;
+    owner_id: string;
+    owner_username: string;
+    creator_id: string;
+    client_class: string;
+  }
+
+  export interface AccessClientCreateInfo extends AccessClientInfo {
+    /** An secret for an API Client */
+    client_secret: string;
+    /** A time in ISO-8601 format */
+    client_secret_expires_at: string;
+    client_secret_name: string;
+    client_secret_description: string;
+  }
+
+  export type AccessRegistryGroup =
+    | "ai-guard-edge"
+    | "redact-edge"
+    | "private-cloud";
+
+  export interface AccessRole {
+    role: string;
+    type: string;
+    id: string | AccessRegistryGroup;
+    service?: string;
+    /** An ID for a service config */
+    service_config_id?: string;
+  }
+
+  export interface AccessClientListResult {
+    clients: AccessClientInfo[];
+    count: number;
+    last?: string;
+  }
+
+  export interface AccessClientSecretInfo {
+    /** An ID for a service account */
+    client_id: string;
+    /** An ID for an API Client secret */
+    client_secret_id: string;
+    /** An secret for an API Client */
+    client_secret: string;
+    /** A time in ISO-8601 format */
+    client_secret_expires_at: string;
+    client_secret_name?: string;
+    client_secret_description?: string;
+  }
+
+  export interface AccessClientSecretMetadata {
+    source_ip: string;
+    user_agent: string;
+    creator: string;
+    creator_id: string;
+    creator_type: string;
+  }
+
+  export interface AccessClientSecretInfoWithMetadata {
+    client_id: string;
+    client_secret_id: string;
+    client_secret_expires_at: string;
+    client_secret_name: string;
+    client_secret_description: string;
+    created_at: string;
+    updated_at: string;
+    client_secret_metadata: AccessClientSecretMetadata;
+  }
+
+  export interface AccessClientSecretInfoListResult {
+    "client-secrets": AccessClientSecretInfoWithMetadata[];
+    count: number;
+    last?: string;
+  }
+
+  export interface AccessRolesListResult {
+    roles: AccessRole[];
+    count: number;
+    last?: string;
+  }
+}
+
 export namespace PromptGuard {
   export interface Message {
     role: string;
@@ -576,6 +987,90 @@ export namespace PromptGuard {
 }
 
 export namespace Redact {
+  export type MatcherType =
+    | "CREDIT_CARD"
+    | "CRYPTO"
+    | "DATE_TIME"
+    | "EMAIL_ADDRESS"
+    | "IBAN_CODE"
+    | "IP_ADDRESS"
+    | "NRP"
+    | "LOCATION"
+    | "PERSON"
+    | "PHONE_NUMBER"
+    | "MEDICAL_LICENSE"
+    | "URL"
+    | "US_BANK_NUMBER"
+    | "US_DRIVER_LICENSE"
+    | "US_ITIN"
+    | "US_PASSPORT"
+    | "US_SSN"
+    | "UK_NHS"
+    | "NIF"
+    | "FIN/NRIC"
+    | "AU_ABN"
+    | "AU_ACN"
+    | "AU_TFN"
+    | "AU_MEDICARE"
+    | "FIREBASE_URL"
+    | "RSA_PRIVATE_KEY"
+    | "SSH_DSA_PRIVATE_KEY"
+    | "SSH_EC_PRIVATE_KEY"
+    | "PGP_PRIVATE_KEY_BLOCK"
+    | "AMAZON_AWS_ACCESS_KEY_ID"
+    | "AMAZON_AWS_SECRET_ACCESS_KEY"
+    | "AMAZON_MWS_AUTH_TOKEN"
+    | "FACEBOOK_ACCESS_TOKEN"
+    | "GITHUB_ACCESS_TOKEN"
+    | "JWT_TOKEN"
+    | "GOOGLE_API_KEY"
+    | "GOOGLE_CLOUD_PLATFORM_API_KEY"
+    | "GOOGLE_DRIVE_API_KEY"
+    | "GOOGLE_CLOUD_PLATFORM_SERVICE_ACCOUNT"
+    | "GOOGLE_GMAIL_API_KEY"
+    | "YOUTUBE_API_KEY"
+    | "MAILCHIMP_API_KEY"
+    | "MAILGUN_API_KEY"
+    | "MONEY"
+    | "BASIC_AUTH"
+    | "PICATIC_API_KEY"
+    | "SLACK_TOKEN"
+    | "SLACK_WEBHOOK"
+    | "STRIPE_API_KEY"
+    | "STRIPE_RESTRICTED_API_KEY"
+    | "SQUARE_ACCESS_TOKEN"
+    | "SQUARE_OAUTH_SECRET"
+    | "TWILIO_API_KEY"
+    | "PANGEA_TOKEN"
+    | "PROFANITY";
+
+  export type Redaction =
+    | { redaction_type: "mask" | "detect_only" }
+    | { redaction_type: "replacement"; redaction_value: string }
+    | { redaction_type: "partial_masking"; partial_masking: PartialMasking }
+    | {
+        redaction_type: "hash";
+        hash?: {
+          /** The type of hashing algorithm */
+          hash_type: "md5" | "sha256";
+        };
+      }
+    | {
+        redaction_type: "fpe";
+        fpe_alphabet?:
+          | "numeric"
+          | "alphalower"
+          | "alphaupper"
+          | "alpha"
+          | "alphanumericlower"
+          | "alphanumericupper"
+          | "alphanumeric";
+        fpe_tweak_vault_secret_id?: string;
+        fpe_tweak?: string;
+      };
+
+  export type RedactionMethodOverrides = Redaction;
+
   export interface TextResult {
     /** The redacted text */
     redacted_text?: string;
@@ -627,32 +1122,7 @@ export namespace Redact {
      * This field allows users to specify the redaction method per rule and its
      * various parameters.
      */
-    redaction_method_overrides?: {
-      [rule: string]:
-        | { redaction_type: "mask" | "detect_only" }
-        | { redaction_type: "replacement"; redaction_value: string }
-        | { redaction_type: "partial_masking"; partial_masking: PartialMasking }
-        | {
-            redaction_type: "hash";
-            hash?: {
-              /** The type of hashing algorithm */
-              hash_type: "md5" | "sha256";
-            };
-          }
-        | {
-            redaction_type: "fpe";
-            fpe_alphabet?:
-              | "numeric"
-              | "alphalower"
-              | "alphaupper"
-              | "alpha"
-              | "alphanumericlower"
-              | "alphanumericupper"
-              | "alphanumeric";
-            fpe_tweak_vault_secret_id?: string;
-            fpe_tweak?: string;
-          };
-    };
+    redaction_method_overrides?: { [rule: string]: RedactionMethodOverrides };
     vault_parameters?: VaultParameters;
 
     /** Is this redact call going to be used in an LLM request? */
@@ -693,7 +1163,7 @@ export namespace Redact {
     masked_from_left?: number;
     masked_from_right?: number;
     chars_to_ignore?: string[];
-    masking_char?: string[];
+    masking_char?: string;
   }
 
   export interface UnredactRequest<O = object> {
@@ -707,6 +1177,132 @@ export namespace Redact {
   export interface UnredactResult<O = object> {
     /** The unredacted data */
     data: O;
+  }
+
+  export interface Matcher {
+    match_type: string;
+    match_value: string;
+    match_score: number;
+  }
+
+  export interface RuleV1 {
+    entity_name: string;
+    matchers: MatcherType | MatcherType[];
+    ruleset: string;
+    match_threshold?: number;
+    context_values?: string[];
+    name?: string;
+    description?: string;
+  }
+
+  export interface RuleV2 {
+    entity_name: string;
+    matchers: MatcherType | MatcherType[];
+    match_threshold?: number;
+    context_values?: string[];
+    negative_context_values?: string[];
+    name?: string;
+    description?: string;
+  }
+
+  export interface RulesetV1 {
+    name?: string;
+    description?: string;
+    rules: string[];
+  }
+
+  export interface RulesetV2 {
+    name?: string;
+    description?: string;
+  }
+
+  export interface ServiceConfigV1 {
+    version: "1.0.0";
+    id: string;
+    name: string;
+    updated_at: string;
+    enabled_rules: string[];
+
+    redactions?: { [key: string]: Redaction };
+    /** Service config used to create the secret */
+    vault_service_config_id?: string;
+    /** Pangea only allows hashing to be done using a salt value to prevent brute-force attacks. */
+    salt_vault_secret_id?: string;
+    rules?: { [key: string]: RuleV1 };
+    rulesets?: { [key: string]: RulesetV1 };
+    supported_languages?: "en"[];
+  }
+
+  export interface ServiceConfigV2 {
+    version: "2.0.0";
+    id: string;
+    name: string;
+    updated_at: string;
+    enabled_rules: string[];
+
+    /** Always run service config enabled rules across all redact calls regardless of flags? */
+    enforce_enabled_rules?: boolean;
+    redactions?: { [key: string]: Redaction };
+    /** Service config used to create the secret */
+    vault_service_config_id?: string;
+    /** Pangea only allows hashing to be done using a salt value to prevent brute-force attacks. */
+    salt_vault_secret_id?: string;
+    rules?: { [key: string]: RuleV2 };
+    rulesets?: { [key: string]: RulesetV2 };
+    supported_languages?: "en"[];
+  }
+
+  export type ServiceConfigResult = ServiceConfigV1 | ServiceConfigV2;
+
+  export interface ServiceConfigFilter {
+    /** Only records where id equals this value. */
+    id?: string;
+
+    /** Only records where id includes each substring. */
+    id__contains?: string[];
+
+    /** Only records where id equals one of the provided substrings. */
+    id__in?: string[];
+
+    /** Only records where created_at equals this value. */
+    created_at?: string;
+
+    /** Only records where created_at is greater than this value. */
+    created_at__gt?: string;
+
+    /** Only records where created_at is greater than or equal to this value. */
+    created_at__gte?: string;
+
+    /** Only records where created_at is less than this value. */
+    created_at__lt?: string;
+
+    /** Only records where created_at is less than or equal to this value. */
+    created_at__lte?: string;
+
+    /** Only records where updated_at equals this value. */
+    updated_at?: string;
+
+    /** Only records where updated_at is greater than this value. */
+    updated_at__gt?: string;
+
+    /** Only records where updated_at is greater than or equal to this value. */
+    updated_at__gte?: string;
+
+    /** Only records where updated_at is less than this value. */
+    updated_at__lt?: string;
+
+    /** Only records where updated_at is less than or equal to this value. */
+    updated_at__lte?: string;
+  }
+
+  export interface ServiceConfigListResult {
+    /** The total number of service configs matched by the list request. */
+    count: number;
+
+    /** Used to fetch the next page of the current listing when provided in a repeated request's last parameter. */
+    last: string;
+
+    items: ServiceConfigResult[];
   }
 }
 

--- a/packages/pangea-node-sdk/yarn.lock
+++ b/packages/pangea-node-sdk/yarn.lock
@@ -426,13 +426,13 @@ __metadata:
   linkType: hard
 
 "@eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
-  version: 4.5.1
-  resolution: "@eslint-community/eslint-utils@npm:4.5.1"
+  version: 4.6.0
+  resolution: "@eslint-community/eslint-utils@npm:4.6.0"
   dependencies:
     eslint-visitor-keys: "npm:^3.4.3"
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10c0/b520ae1b7bd04531a5c5da2021071815df4717a9f7d13720e3a5ddccf5c9c619532039830811fcbae1c2f1c9d133e63af2435ee69e0fc0fabbd6d928c6800fb2
+  checksum: 10c0/a64131c1b43021e3a84267f6011fd678a936718097c9be169c37a40ada2c7016bec7d6685ecc88112737d57733f36837bb90d9425ad48d2e2aa351d999d32443
   languageName: node
   linkType: hard
 
@@ -468,15 +468,15 @@ __metadata:
   linkType: hard
 
 "@gerrit0/mini-shiki@npm:^3.2.2":
-  version: 3.2.2
-  resolution: "@gerrit0/mini-shiki@npm:3.2.2"
+  version: 3.2.3
+  resolution: "@gerrit0/mini-shiki@npm:3.2.3"
   dependencies:
-    "@shikijs/engine-oniguruma": "npm:^3.2.1"
-    "@shikijs/langs": "npm:^3.2.1"
-    "@shikijs/themes": "npm:^3.2.1"
-    "@shikijs/types": "npm:^3.2.1"
+    "@shikijs/engine-oniguruma": "npm:^3.2.2"
+    "@shikijs/langs": "npm:^3.2.2"
+    "@shikijs/themes": "npm:^3.2.2"
+    "@shikijs/types": "npm:^3.2.2"
     "@shikijs/vscode-textmate": "npm:^10.0.2"
-  checksum: 10c0/0714ddea5a3d727b7b8a517f01b45a03f4134c8716b435a92d3087d2ab657ec0488c5da9416159a74835f2eef6b44982190707a1ae9c31ac38ba6acf63b51dd1
+  checksum: 10c0/79dde63c9f396f5629c9f018a3d1b27a2d6d74f98654792d6e04b607e7256649afe3d1920114ca8ddcae7e005f356922d121679d5b8df5d8ccf637a3f40b818c
   languageName: node
   linkType: hard
 
@@ -915,10 +915,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "@pkgr/core@npm:0.2.0"
-  checksum: 10c0/29cb9c15f4788096b8b8b786b19c75b6398b6afe814a97189922c3046d8acb5d24f1217fd2537c3f8e42c04e48d572295e7ee56d77964ddc932c44eb5a615931
+"@pkgr/core@npm:^0.2.3":
+  version: 0.2.4
+  resolution: "@pkgr/core@npm:0.2.4"
+  checksum: 10c0/2528a443bbbef5d4686614e1d73f834f19ccbc975f62b2a64974a6b97bcdf677b9c5e8948e04808ac4f0d853e2f422adfaae2a06e9e9f4f5cf8af76f1adf8dc1
   languageName: node
   linkType: hard
 
@@ -929,41 +929,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/engine-oniguruma@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "@shikijs/engine-oniguruma@npm:3.2.1"
+"@shikijs/engine-oniguruma@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@shikijs/engine-oniguruma@npm:3.2.2"
   dependencies:
-    "@shikijs/types": "npm:3.2.1"
+    "@shikijs/types": "npm:3.2.2"
     "@shikijs/vscode-textmate": "npm:^10.0.2"
-  checksum: 10c0/8c4c51738740f9cfa610ccefaaea2378833820336e4329bb88b9a2208e3deb994b0b7bea2d6657eb915fb668ca2090a2168a84dfeac2b820c1fee00631ca9bed
+  checksum: 10c0/b5eedfca26f7e1525fd079c1827ae9bdedafb574ce4eb535c54d484218b7428fb9ac93607f79a2adc1482483dd0366fdf07b0846403a76cd4767649adb8fa590
   languageName: node
   linkType: hard
 
-"@shikijs/langs@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "@shikijs/langs@npm:3.2.1"
+"@shikijs/langs@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@shikijs/langs@npm:3.2.2"
   dependencies:
-    "@shikijs/types": "npm:3.2.1"
-  checksum: 10c0/8a4e8c066795f1e96686bee271ad9783febcb1cece2ebb9815dfb3d59c856ac869cf9dddc7d90cbcd186a782ddc0628b37486fcc4a46516be6825907f0e74178
+    "@shikijs/types": "npm:3.2.2"
+  checksum: 10c0/04b5c9b92de9070624d24e20a2b3607edcbe4894a1db8056927f0d0637f080e2eed4e54925f0ded36874361db14bab9e4d9c2d06614ddd733f3f314250eabaf8
   languageName: node
   linkType: hard
 
-"@shikijs/themes@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "@shikijs/themes@npm:3.2.1"
+"@shikijs/themes@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@shikijs/themes@npm:3.2.2"
   dependencies:
-    "@shikijs/types": "npm:3.2.1"
-  checksum: 10c0/674aae42244832142f584037504ab102dc141f9918f5b11b62aa0dc1abb6a763daf74f86124ae5f2362116dd095b5fc62c9a249aa8c14fdae847e5b8b955b11b
+    "@shikijs/types": "npm:3.2.2"
+  checksum: 10c0/93745e76e7ed6cab1d797ec68b53a0a183d989201e5064b33a78b516e128848d2c9be194d29cf602d5017dc2a74013699c773d052aeb45593851ae35b035afaa
   languageName: node
   linkType: hard
 
-"@shikijs/types@npm:3.2.1, @shikijs/types@npm:^3.2.1":
-  version: 3.2.1
-  resolution: "@shikijs/types@npm:3.2.1"
+"@shikijs/types@npm:3.2.2, @shikijs/types@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@shikijs/types@npm:3.2.2"
   dependencies:
     "@shikijs/vscode-textmate": "npm:^10.0.2"
     "@types/hast": "npm:^3.0.4"
-  checksum: 10c0/3380fde198d466a8771137b7ca3d4756a54d7d24c6e65f852737472a280c12c07f2123b9ad3d7eb2edec86d8d2c53bc207abe0fc0c7f78d337e52e742dc34edf
+  checksum: 10c0/aec3327d0cfc89af138ce195ac070ba62d8229864c079a3f06dff5a180036fdd963282068d67bd4c89a04ae688005c2b7c214c274ad0bb265f6f7ab6907a67a6
   languageName: node
   linkType: hard
 
@@ -1333,11 +1333,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 22.14.0
-  resolution: "@types/node@npm:22.14.0"
+  version: 22.14.1
+  resolution: "@types/node@npm:22.14.1"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/9d79f3fa1af9c2c869514f419c4a4905b34c10e12915582fd1784868ac4e74c6d306cf5eb47ef889b6750ab85a31be96618227b86739c4a3e0b1c15063f384c6
+  checksum: 10c0/d49c4d00403b1c2348cf0701b505fd636d80aabe18102105998dc62fdd36dcaf911e73c7a868c48c21c1022b825c67b475b65b1222d84b704d8244d152bb7f86
   languageName: node
   linkType: hard
 
@@ -1473,16 +1473,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.29.0":
-  version: 8.29.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.29.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.29.0"
-    "@typescript-eslint/visitor-keys": "npm:8.29.0"
-  checksum: 10c0/330d777043a99485b51197ad24927f1276d61e61adaf710f012b3fe7db2ab67c8925c0526f801715b498e7d8fa7cef390006b6f7ae40cee89abe22e8e438de9a
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.29.1":
   version: 8.29.1
   resolution: "@typescript-eslint/scope-manager@npm:8.29.1"
@@ -1490,6 +1480,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.29.1"
     "@typescript-eslint/visitor-keys": "npm:8.29.1"
   checksum: 10c0/8b87a04f01ebc13075e352509bca8f31c757c3220857fa473ac155f6bdf7f30fe82765d0c3d8e790f7fad394a32765bd9f716b97c08e17581d358c76086d51af
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.30.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.30.1"
+    "@typescript-eslint/visitor-keys": "npm:8.30.1"
+  checksum: 10c0/8560fd02bb2a73b56f79af1dfa311491926f3625a04c0f32777c7c0bdec47b4a677addf2d2e2cc313416bb59b7a6e0bff7837449816a5ec5ff81e923daa76ca7
   languageName: node
   linkType: hard
 
@@ -1532,17 +1532,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.29.0":
-  version: 8.29.0
-  resolution: "@typescript-eslint/types@npm:8.29.0"
-  checksum: 10c0/fc1e3f3071102973a9cfb8ae843c51398bd74b5583b7b0edad182ea605ef85e72ceac7987513581869958b3a65303af6b3471bfba5b7be1338e8add62019c858
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/types@npm:8.29.1":
   version: 8.29.1
   resolution: "@typescript-eslint/types@npm:8.29.1"
   checksum: 10c0/bbcb9e4f38df4485092b51ac6bb62d65f321d914ab58dc0ff1eaa7787dc0b4a39e237c2617b9f2c2bcb91a343f30de523e3544f69affa1ee4287a3ef2fc10ce7
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/types@npm:8.30.1"
+  checksum: 10c0/461e800bf911c24d9b61bdbeed897921454acc0c24b4e8a79f943c14234241828c13a31dce31dcce77511185f806a2fb94769075e122e3182ba5a32dd55573eb
   languageName: node
   linkType: hard
 
@@ -1565,24 +1565,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.29.0":
-  version: 8.29.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.29.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.29.0"
-    "@typescript-eslint/visitor-keys": "npm:8.29.0"
-    debug: "npm:^4.3.4"
-    fast-glob: "npm:^3.3.2"
-    is-glob: "npm:^4.0.3"
-    minimatch: "npm:^9.0.4"
-    semver: "npm:^7.6.0"
-    ts-api-utils: "npm:^2.0.1"
-  peerDependencies:
-    typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/61dd52229a0758e0bd29f732115c16e640a2418fb25488877c74ef03cdbeb43ddc592a37094abd794ef49812f33d6f814c5b662b95ea796ed0a6c6bfc849299b
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/typescript-estree@npm:8.29.1":
   version: 8.29.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.29.1"
@@ -1598,6 +1580,24 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4 <5.9.0"
   checksum: 10c0/33c46c667d9262e5625d5d0064338711b342e62c5675ded6811a2cb13ee5de2f71b90e9d0be5cb338b11b1a329c376a6bbf6c3d24fa8fb457b2eefc9f3298513
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.30.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.30.1"
+    "@typescript-eslint/visitor-keys": "npm:8.30.1"
+    debug: "npm:^4.3.4"
+    fast-glob: "npm:^3.3.2"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^2.0.1"
+  peerDependencies:
+    typescript: ">=4.8.4 <5.9.0"
+  checksum: 10c0/9eb0b1bc4b5df37c84ac411d77ce0edf934b5fdde021ed45c984aa7894132ff7a276d2b95e2d29ef84c411df8ecdf096eec3e07ec1ee5b1fa8c623d40a82ecf0
   languageName: node
   linkType: hard
 
@@ -1631,17 +1631,17 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/utils@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.29.0
-  resolution: "@typescript-eslint/utils@npm:8.29.0"
+  version: 8.30.1
+  resolution: "@typescript-eslint/utils@npm:8.30.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
-    "@typescript-eslint/scope-manager": "npm:8.29.0"
-    "@typescript-eslint/types": "npm:8.29.0"
-    "@typescript-eslint/typescript-estree": "npm:8.29.0"
+    "@typescript-eslint/scope-manager": "npm:8.30.1"
+    "@typescript-eslint/types": "npm:8.30.1"
+    "@typescript-eslint/typescript-estree": "npm:8.30.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <5.9.0"
-  checksum: 10c0/e259d7edd12946b2dc8e1aa3bbea10f66c5277f27dda71368aa2b2923487f28cd1c123681aaae22518a31c8aeabd60a5365f8a832d0f6e6efadb03745a2d8a31
+  checksum: 10c0/ad54aa386edc2e19957c73ef25eea3e263e7e15e941c72e91ca6c8ea2536979d343a6069de0e40b15f0e732ddaacbfcc3d5f25a1583e11a32120c42c471802ea
   languageName: node
   linkType: hard
 
@@ -1655,16 +1655,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.29.0":
-  version: 8.29.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.29.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.29.0"
-    eslint-visitor-keys: "npm:^4.2.0"
-  checksum: 10c0/7f5452b137c4edd258b2289cddf5d92687780375db33421bc4f5e2e9b0c94064c7c5ed3a7b5d96dc9c2d09ca7842b4415b3f3ed3e3f1ae3ac2e625ecb5e87efc
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/visitor-keys@npm:8.29.1":
   version: 8.29.1
   resolution: "@typescript-eslint/visitor-keys@npm:8.29.1"
@@ -1672,6 +1662,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.29.1"
     eslint-visitor-keys: "npm:^4.2.0"
   checksum: 10c0/0c12e83c84a754161c89e594a96454799669979c7021a8936515ec574a1fa1d6e3119e0eacf502e07a0fa7254974558ea7a48901c8bfed3c46579a61b655e4f5
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.30.1":
+  version: 8.30.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.30.1"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.30.1"
+    eslint-visitor-keys: "npm:^4.2.0"
+  checksum: 10c0/bdc182289c68a5c8f891f9aecf6ccb59743c3f2b1bbe57f57f8c7ce1688f4381182e301919895cefc929539eea914eeb847f7d351cdc3f685ed6c5ee67a10c9e
   languageName: node
   linkType: hard
 
@@ -1683,9 +1683,9 @@ __metadata:
   linkType: hard
 
 "abbrev@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "abbrev@npm:3.0.0"
-  checksum: 10c0/049704186396f571650eb7b22ed3627b77a5aedf98bb83caf2eac81ca2a3e25e795394b0464cfb2d6076df3db6a5312139eac5b6a126ca296ac53c5008069c28
+  version: 3.0.1
+  resolution: "abbrev@npm:3.0.1"
+  checksum: 10c0/21ba8f574ea57a3106d6d35623f2c4a9111d9ee3e9a5be47baed46ec2457d2eac46e07a5c4a60186f88cb98abbe3e24f2d4cca70bc2b12f1692523e2209a9ccf
   languageName: node
   linkType: hard
 
@@ -2192,9 +2192,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001709
-  resolution: "caniuse-lite@npm:1.0.30001709"
-  checksum: 10c0/0acf91f59f52661fc47042e4eee1b527deb54044ae4c79ae7464d0789b79146ad587153a76d78b09157261b9fad89235eb161cd8ea7a58d36fc7f25a2e937df5
+  version: 1.0.30001713
+  resolution: "caniuse-lite@npm:1.0.30001713"
+  checksum: 10c0/f5468abfe73ce30e29cc8bde2ea67df2aab69032bdd93345e0640efefb76b7901c84fe1d28d591a797e65fe52fc24cae97060bb5552f9f9740322aff95ce2f9d
   languageName: node
   linkType: hard
 
@@ -2656,9 +2656,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.73":
-  version: 1.5.130
-  resolution: "electron-to-chromium@npm:1.5.130"
-  checksum: 10c0/524a7a467a22fd330699bd73d278b8b421fac24ab9fe5a40e68320ec16dd5d05616f5f1471a3942593767497fef6297b87c333cccecbf0b8ed6f3b9256b41be7
+  version: 1.5.137
+  resolution: "electron-to-chromium@npm:1.5.137"
+  checksum: 10c0/678613e0a3d023563a1acca4d8103a69d389168efeb3b78c1fcc683ed0778d81bfb00c6f621d6535f3fa9530664fc948fc8f2ed27e7548d46cd3987d4b0add6a
   languageName: node
   linkType: hard
 
@@ -5315,6 +5315,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"neoqs@npm:^6.13.0":
+  version: 6.13.0
+  resolution: "neoqs@npm:6.13.0"
+  checksum: 10c0/646f4698b44e2479ca53be8530ebff704495db1db382b6a774ef621ef3456d17defad396d9256dd85c46b7ce5c7b7344e0231913e3b79ffbc84773efa8976810
+  languageName: node
+  linkType: hard
+
 "node-gyp@npm:latest":
   version: 11.2.0
   resolution: "node-gyp@npm:11.2.0"
@@ -5609,6 +5616,7 @@ __metadata:
     jest: "npm:29.7.0"
     json-canon: "npm:^1.0.1"
     merkle-tools: "npm:^1.4.1"
+    neoqs: "npm:^6.13.0"
     promise-retry: "npm:^2.0.1"
     ts-node: "npm:^10.9.2"
     tsc-alias: "npm:^1.8.15"
@@ -6662,12 +6670,12 @@ __metadata:
   linkType: hard
 
 "synckit@npm:^0.11.0":
-  version: 0.11.1
-  resolution: "synckit@npm:0.11.1"
+  version: 0.11.4
+  resolution: "synckit@npm:0.11.4"
   dependencies:
-    "@pkgr/core": "npm:^0.2.0"
+    "@pkgr/core": "npm:^0.2.3"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/284f6137eaf31c999634fcbe82a8fb23e50c507da2abe930714080cdd7af4365c2fa3bbab4694d451d8e0b48395ec01ffca5a83fb571a415ff4a52b2d9d3309d
+  checksum: 10c0/dd2965a37c93c0b652bf07b1fd8d1639a803b65cf34c0cb1b827b8403044fc3b09ec87f681d922a324825127ee95b2e0394e7caccb502f407892d63e903c5276
   languageName: node
   linkType: hard
 
@@ -6968,17 +6976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5":
-  version: 5.8.2
-  resolution: "typescript@npm:5.8.2"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/5c4f6fbf1c6389b6928fe7b8fcd5dc73bb2d58cd4e3883f1d774ed5bd83b151cbac6b7ecf11723de56d4676daeba8713894b1e9af56174f2f9780ae7848ec3c6
-  languageName: node
-  linkType: hard
-
-"typescript@npm:5.8.3":
+"typescript@npm:5, typescript@npm:5.8.3":
   version: 5.8.3
   resolution: "typescript@npm:5.8.3"
   bin:
@@ -6988,17 +6986,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5#optional!builtin<compat/typescript>":
-  version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/5448a08e595cc558ab321e49d4cac64fb43d1fa106584f6ff9a8d8e592111b373a995a1d5c7f3046211c8a37201eb6d0f1566f15cdb7a62a5e3be01d087848e2
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>":
   version: 5.8.3
   resolution: "typescript@patch:typescript@npm%3A5.8.3#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:


### PR DESCRIPTION
Some of the new APIs don't follow the standard Pangea response schema, so a little bit of refactoring is required. Also, there is more usage of GET requests with query parameters, so there are changes here to support that as well.