### PR TITLE
pangea-node-sdk: add `baseUrlTemplate`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [20, 22]
     defaults:
       run:
         working-directory: ./packages/pangea-node-sdk

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 default:
-  image: node:18.20.8@sha256:df9fa4e0e39c9b97e30240b5bb1d99bdb861573a82002b2c52ac7d6b8d6d773e
+  image: node:20.19.0@sha256:a5fb035ac1dff34a4ecaea85f90f7321185695d3fd22c12ba12f4535a4647cc5
   tags:
     - pangea-internal
 

--- a/examples/.examples-ci.yml
+++ b/examples/.examples-ci.yml
@@ -6,7 +6,7 @@ examples-tests:
     - pangea-node-sdk-integration-tests
   parallel:
     matrix:
-      - NODE_VERSION: [18, 20]
+      - NODE_VERSION: [20, 22]
         TEST_FOLDER:
           - "audit"
           - "authn"

--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Guard: detector overrides.
 - AI Guard: topic detector.
 - AI Guard: `ignore_recipe` in detector overrides.
+- `baseUrlTemplate` has been added to `PangeaConfig` to allow for greater
+  control over the complete API URL. This option may be a full URL with the
+  optional `{SERVICE_NAME}` placeholder, which will be replaced by the slug of
+  the respective service name. This supersedes `environment` and `insecure`.
 
 ### Changed
 

--- a/packages/pangea-node-sdk/CHANGELOG.md
+++ b/packages/pangea-node-sdk/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Support for Node.js v18. The minimum supported version is now Node.js v20.
 - Deprecated APIs like `PangeaConfig.configID`, `Vault.AsymmetricAlgorithm.RSA`,
   and `Vault.SymmetricAlgorithm.AES`.
 - AI Guard: `llm_info` and `llm_input`.

--- a/packages/pangea-node-sdk/README.md
+++ b/packages/pangea-node-sdk/README.md
@@ -8,8 +8,8 @@
 
 # Pangea Node.js SDK
 
-A Node.js SDK for integrating with Pangea services. Supports Node.js v18 and
-v20.
+A Node.js SDK for integrating with Pangea services. Supports Node.js v20 and
+v22.
 
 ## Installation
 

--- a/packages/pangea-node-sdk/package.json
+++ b/packages/pangea-node-sdk/package.json
@@ -18,11 +18,11 @@
       }
     }
   },
-  "repository": "git@github.com:pangeacyber/pangea-javascript.git",
+  "repository": "github:pangeacyber/pangea-javascript",
   "author": "Glenn Gallien <glenn.gallien@pangea.cloud>",
   "license": "MIT",
   "engines": {
-    "node": "18 || >=20"
+    "node": "20 || >=22"
   },
   "packageManager": "yarn@4.9.1",
   "dependencies": {
@@ -41,7 +41,7 @@
     "@tsconfig/node18": "18.2.4",
     "@types/crypto-js": "^4.2.2",
     "@types/jest": "29.5.14",
-    "@types/node": "18.19.86",
+    "@types/node": "20.17.30",
     "@types/promise-retry": "1.1.6",
     "@typescript-eslint/eslint-plugin": "8.30.1",
     "@typescript-eslint/parser": "8.30.1",

--- a/packages/pangea-node-sdk/src/config.ts
+++ b/packages/pangea-node-sdk/src/config.ts
@@ -1,26 +1,23 @@
-import { ConfigOptions, ConfigEnv } from "./types.js";
-
 export const version = "4.4.0";
 
 /** Configuration for a Pangea service client. */
 class PangeaConfig {
-  /** Pangea API domain. */
-  domain: string = "pangea.cloud";
+  /**
+   * Template for constructing the base URL for API requests. The placeholder
+   * `{SERVICE_NAME}` will be replaced with the service name slug. This is a
+   * more powerful version of `domain` that allows for setting more than just
+   * the host of the API server. Defaults to
+   * `https://{SERVICE_NAME}.aws.us.pangea.cloud`.
+   */
+  baseUrlTemplate: string = "https://{SERVICE_NAME}.aws.us.pangea.cloud";
 
   /**
-   * Pangea environment.
-   *
-   * If set to `ConfigEnv.LOCAL`, then `domain` must be the full host (i.e.,
-   * hostname and port) for the Pangea service that this `PangeaConfig` will be
-   * used for.
+   * Base domain for API requests. This is a weaker version of `baseUrlTemplate`
+   * that only allows for setting the host of the API server. Use
+   * BaseURLTemplate for more control over the URL, such as setting
+   * service-specific paths. Defaults to `aws.us.pangea.cloud`.
    */
-  environment: ConfigEnv = ConfigEnv.PRODUCTION;
-
-  /**
-   * Whether or not to perform requests via plain HTTP, as opposed to secure
-   * HTTPS.
-   */
-  insecure: boolean = false;
+  domain: string = "aws.us.pangea.cloud";
 
   /** How many times a request should be retried on failure. */
   requestRetries: number = 3;
@@ -45,7 +42,17 @@ class PangeaConfig {
    *
    * @param options Configuration options.
    */
-  constructor(options?: ConfigOptions) {
+  constructor(options?: Partial<PangeaConfig>) {
+    options = options || {};
+
+    if (!options.baseUrlTemplate && !options.domain) {
+      options.baseUrlTemplate = "https://{SERVICE_NAME}.aws.us.pangea.cloud";
+    }
+
+    if (!options.baseUrlTemplate && options.domain) {
+      options.baseUrlTemplate = `https://{SERVICE_NAME}.${options.domain}`;
+    }
+
     Object.assign(this, options);
   }
 }

--- a/packages/pangea-node-sdk/src/errors.ts
+++ b/packages/pangea-node-sdk/src/errors.ts
@@ -91,10 +91,10 @@ export namespace PangeaErrors {
   }
 
   //Too many requests were made
-  export class RateLimiteError extends APIError {
+  export class RateLimitError extends APIError {
     constructor(message: string, response: PangeaResponse<any>) {
       super(message, response);
-      this.name = "RateLimiteError";
+      this.name = "RateLimitError";
     }
   }
 

--- a/packages/pangea-node-sdk/src/file_uploader.ts
+++ b/packages/pangea-node-sdk/src/file_uploader.ts
@@ -23,7 +23,7 @@ export class FileUploader {
 
   // TODO: Docs
   public async uploadFile(
-    url: string,
+    url: URL,
     fileData: FileData,
     options: {
       transfer_method?: TransferMethod;

--- a/packages/pangea-node-sdk/src/request.ts
+++ b/packages/pangea-node-sdk/src/request.ts
@@ -380,6 +380,8 @@ class PangeaRequest {
     const fetchOptions: RequestInit = {
       duplex: "half",
       method: options.method,
+      // @ts-expect-error difference in `FormData` types between undici-types
+      // and formdata-node.
       body: options.body,
       headers: options.headers,
     };

--- a/packages/pangea-node-sdk/src/services/base.ts
+++ b/packages/pangea-node-sdk/src/services/base.ts
@@ -80,7 +80,7 @@ class BaseService {
     return await this.request.post(endpoint, data, options);
   }
 
-  async downloadFile(url: string): Promise<AttachedFile> {
+  async downloadFile(url: URL): Promise<AttachedFile> {
     return await this.request.downloadFile(url);
   }
 

--- a/packages/pangea-node-sdk/src/services/file_scan.ts
+++ b/packages/pangea-node-sdk/src/services/file_scan.ts
@@ -151,7 +151,7 @@ export class FileScanUploader {
 
   // TODO: Docs
   public async uploadFile(
-    url: string,
+    url: URL,
     fileData: FileData,
     options: {
       transfer_method?: TransferMethod;

--- a/packages/pangea-node-sdk/src/types.ts
+++ b/packages/pangea-node-sdk/src/types.ts
@@ -1,58 +1,10 @@
 import { Signer } from "./utils/signer.js";
 
-/**
- * PangeaConfig options
- */
-export interface ConfigOptions {
-  /** Pangea API domain. */
-  domain?: string;
-
-  /**
-   * Pangea environment.
-   *
-   * This is intended to facilitate SDK development and should not be touched in
-   * everyday usage.
-   */
-  environment?: ConfigEnv;
-
-  /** Config ID for multi-config projects. */
-  configID?: string;
-
-  /**
-   * Whether or not to perform requests via plain HTTP, as opposed to secure
-   * HTTPS.
-   */
-  insecure?: boolean;
-
-  /** How many times a request should be retried on failure. */
-  requestRetries?: number;
-
-  /** Maximum allowed time (in milliseconds) for a request to complete. */
-  requestTimeout?: number;
-
-  /** Whether or not queued request retries are enabled. */
-  queuedRetryEnabled?: boolean;
-
-  /** Timeout for polling results after a HTTP/202 (in milliseconds). */
-  pollResultTimeoutMs?: number;
-
-  /** How many queued request retries there should be on failure. */
-  queuedRetries?: number;
-
-  /** User-Agent string to append to the default one. */
-  customUserAgent?: string;
-}
-
 export type PangeaToken = string | ({ type: "pangea_token" } & Vault.GetResult);
 
 export interface PostOptions {
   pollResultSync?: boolean;
   files?: FileItems;
-}
-
-export enum ConfigEnv {
-  LOCAL = "local",
-  PRODUCTION = "production",
 }
 
 export enum TransferMethod {

--- a/packages/pangea-node-sdk/tests/integration/audit.test.ts
+++ b/packages/pangea-node-sdk/tests/integration/audit.test.ts
@@ -1044,7 +1044,9 @@ it(
     expect(downloadResp.status).toBe("Success");
     expect(downloadResp.result.dest_url).toBeDefined();
 
-    const file = await auditGeneral.downloadFile(downloadResp.result.dest_url);
+    const file = await auditGeneral.downloadFile(
+      new URL(downloadResp.result.dest_url)
+    );
 
     file.save("./");
   }),

--- a/packages/pangea-node-sdk/tests/integration/file_scan.test.ts
+++ b/packages/pangea-node-sdk/tests/integration/file_scan.test.ts
@@ -168,7 +168,7 @@ it("File Scan get url and put upload", async () => {
   };
   let response = await fileScan.requestUploadURL(request);
 
-  const url = response.accepted_result?.put_url || "";
+  const url = new URL(response.accepted_result?.put_url || "");
 
   const uploader = new FileScanUploader();
   await uploader.uploadFile(
@@ -221,7 +221,7 @@ it("File Scan get url and post upload", async () => {
     return;
   }
 
-  const url = response.accepted_result?.post_url || "";
+  const url = new URL(response.accepted_result?.post_url || "");
   const file_details = response.accepted_result?.post_form_data;
 
   const uploader = new FileScanUploader();

--- a/packages/pangea-node-sdk/tests/integration/sanitize.test.ts
+++ b/packages/pangea-node-sdk/tests/integration/sanitize.test.ts
@@ -1,5 +1,6 @@
-import PangeaConfig from "../../src/config.js";
 import { it, expect, jest } from "@jest/globals";
+
+import PangeaConfig from "../../src/config.js";
 import {
   TestEnvironment,
   getCustomSchemaTestToken,
@@ -147,7 +148,9 @@ it("Sanitize no share", async () => {
     expect(response.result.data.malicious_file).toBeFalsy();
 
     if (response.result.dest_url) {
-      const attachedFile = await client.downloadFile(response.result.dest_url);
+      const attachedFile = await client.downloadFile(
+        new URL(response.result.dest_url)
+      );
       attachedFile.save("./");
     }
   } catch (e) {
@@ -189,7 +192,9 @@ it("Sanitize all defaults", async () => {
   }
   expect(response.result.data.malicious_file).toBeFalsy();
   if (response.result.dest_url) {
-    const attachedFile = await client.downloadFile(response.result.dest_url);
+    const attachedFile = await client.downloadFile(
+      new URL(response.result.dest_url)
+    );
     attachedFile.save("./");
   }
 });
@@ -246,7 +251,9 @@ it("Sanitize multipart upload", async () => {
   expect(response.result.data.malicious_file).toBeFalsy();
 
   if (response.result.dest_url) {
-    const attachedFile = await client.downloadFile(response.result.dest_url);
+    const attachedFile = await client.downloadFile(
+      new URL(response.result.dest_url)
+    );
     attachedFile.save("./");
   }
 });
@@ -307,7 +314,7 @@ it("Sanitize async and poll result", async () => {
       expect(response.result.data.malicious_file).toBeFalsy();
       if (response.result.dest_url) {
         const attachedFile = await client.downloadFile(
-          response.result.dest_url
+          new URL(response.result.dest_url)
         );
         attachedFile.save("./");
       }
@@ -342,7 +349,7 @@ it("Sanitize get url and put upload", async () => {
 
   const uploader = new FileUploader();
   await uploader.uploadFile(
-    url,
+    new URL(url),
     {
       file: testfilePath,
       name: "file",
@@ -377,7 +384,7 @@ it("Sanitize get url and put upload", async () => {
       expect(response.result.data.malicious_file).toBeFalsy();
       if (response.result.dest_url) {
         const attachedFile = await client.downloadFile(
-          response.result.dest_url
+          new URL(response.result.dest_url)
         );
         attachedFile.save("./");
       }
@@ -417,7 +424,7 @@ it("Sanitize get url and post upload", async () => {
 
   const uploader = new FileUploader();
   await uploader.uploadFile(
-    url,
+    new URL(url),
     {
       file: testfilePath,
       name: "file",
@@ -453,7 +460,7 @@ it("Sanitize get url and post upload", async () => {
       expect(response.result.data.malicious_file).toBeFalsy();
       if (response.result.dest_url) {
         const attachedFile = await client.downloadFile(
-          response.result.dest_url
+          new URL(response.result.dest_url)
         );
         attachedFile.save("./");
       }

--- a/packages/pangea-node-sdk/tests/integration/share.test.ts
+++ b/packages/pangea-node-sdk/tests/integration/share.test.ts
@@ -197,7 +197,7 @@ it("get url and put upload", async () => {
     throw e;
   }
 
-  const url = response.accepted_result?.put_url || "";
+  const url = new URL(response.accepted_result?.put_url || "");
 
   const uploader = new FileUploader();
   await uploader.uploadFile(
@@ -253,7 +253,7 @@ it("get url and post upload", async () => {
 
   const uploader = new FileUploader();
   await uploader.uploadFile(
-    url,
+    new URL(url),
     {
       file: testFilePath,
       name: name,
@@ -379,7 +379,7 @@ it("Item life cycle", async () => {
 
   // Download file
   const url = respGetArchive2.result.dest_url ?? "";
-  let downloadedFile = await client.downloadFile(url);
+  let downloadedFile = await client.downloadFile(new URL(url));
   downloadedFile.save("./download/");
   expect(downloadedFile.file.byteLength).toBeGreaterThan(0);
 

--- a/packages/pangea-node-sdk/tests/unit/config.test.ts
+++ b/packages/pangea-node-sdk/tests/unit/config.test.ts
@@ -1,68 +1,36 @@
-import PangeaConfig from "@src/config.js";
-import { ConfigEnv } from "@src/types.js";
 import { it, expect } from "@jest/globals";
+
+import PangeaConfig from "@src/config.js";
 import PangeaRequest from "@src/request.js";
 
 const token = "faketoken";
-const domain = "domain.test";
-const path = "path";
 const serviceName = "serviceName";
 
-it("insecure true, environment local", async () => {
+it("should be able to set base URL template", () => {
   const config = new PangeaConfig({
-    domain: domain,
-    insecure: true,
-    environment: ConfigEnv.LOCAL,
-  });
-  const request = new PangeaRequest(serviceName, token, config, undefined);
-  const url = request.getUrl(path);
-  expect(url).toBe("http://" + domain + "/" + path);
-});
-
-it("insecure false, environment local", async () => {
-  const config = new PangeaConfig({
-    domain: domain,
-    insecure: false,
-    environment: ConfigEnv.LOCAL,
+    baseUrlTemplate: "https://example.org/{SERVICE_NAME}",
   });
   const request = new PangeaRequest(serviceName, token, config);
-  const url = request.getUrl(path);
-  expect(url).toBe("https://" + domain + "/" + path);
+  expect(request.getUrl("api")).toStrictEqual(
+    new URL("https://example.org/serviceName/api")
+  );
 });
 
-it("insecure true, environment production", async () => {
+it("should be able to set domain", () => {
+  const config = new PangeaConfig({ domain: "example.org" });
+  const request = new PangeaRequest(serviceName, token, config);
+  expect(request.getUrl("api")).toStrictEqual(
+    new URL("https://servicename.example.org/api")
+  );
+});
+
+it("should prefer base URL template over domain", () => {
   const config = new PangeaConfig({
-    domain: domain,
-    insecure: true,
-    environment: ConfigEnv.PRODUCTION,
+    baseUrlTemplate: "https://example.org/{SERVICE_NAME}",
+    domain: "example.net",
   });
   const request = new PangeaRequest(serviceName, token, config);
-  const url = request.getUrl(path);
-  expect(url).toBe("http://" + serviceName + "." + domain + "/" + path);
-});
-
-it("insecure false, environment production", async () => {
-  const config = new PangeaConfig({
-    domain: domain,
-    insecure: false,
-    environment: ConfigEnv.PRODUCTION,
-  });
-  const request = new PangeaRequest(serviceName, token, config);
-  const url = request.getUrl(path);
-  expect(url).toBe("https://" + serviceName + "." + domain + "/" + path);
-});
-
-it("insecure default, environment default", async () => {
-  const config = new PangeaConfig({ domain: domain });
-  const request = new PangeaRequest(serviceName, token, config);
-  const url = request.getUrl(path);
-  expect(url).toBe("https://" + serviceName + "." + domain + "/" + path);
-});
-
-it("url domain", async () => {
-  const urlDomain = "https://myurldomain.net";
-  const config = new PangeaConfig({ domain: urlDomain });
-  const request = new PangeaRequest(serviceName, token, config);
-  const url = request.getUrl(path);
-  expect(url).toBe(urlDomain + "/" + path);
+  expect(request.getUrl("api")).toStrictEqual(
+    new URL("https://example.org/serviceName/api")
+  );
 });

--- a/packages/pangea-node-sdk/yarn.lock
+++ b/packages/pangea-node-sdk/yarn.lock
@@ -1341,12 +1341,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:18.19.86":
-  version: 18.19.86
-  resolution: "@types/node@npm:18.19.86"
+"@types/node@npm:20.17.30":
+  version: 20.17.30
+  resolution: "@types/node@npm:20.17.30"
   dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10c0/1017c4ba61661ab30e4b4a78040cb66980919549f56d85755326dcccbe7a0405be7d6be1b2a91bace8eaef0d2a24b63d4f104b381be7f957c2483e465d829690
+    undici-types: "npm:~6.19.2"
+  checksum: 10c0/649782c7822367d751472d70c948bcc50cded1a4744610f706f81cd54e1fc015523567d7e3e17f6b19e3e2797f6f23b653e898bdb4a2f21f8759ceba49976310
   languageName: node
   linkType: hard
 
@@ -5592,7 +5592,7 @@ __metadata:
     "@tsconfig/node18": "npm:18.2.4"
     "@types/crypto-js": "npm:^4.2.2"
     "@types/jest": "npm:29.5.14"
-    "@types/node": "npm:18.19.86"
+    "@types/node": "npm:20.17.30"
     "@types/promise-retry": "npm:1.1.6"
     "@typescript-eslint/eslint-plugin": "npm:8.30.1"
     "@typescript-eslint/parser": "npm:8.30.1"
@@ -7007,10 +7007,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~5.26.4":
-  version: 5.26.5
-  resolution: "undici-types@npm:5.26.5"
-  checksum: 10c0/bb673d7876c2d411b6eb6c560e0c571eef4a01c1c19925175d16e3a30c4c428181fb8d7ae802a261f283e4166a0ac435e2f505743aa9e45d893f9a3df017b501
+"undici-types@npm:~6.19.2":
+  version: 6.19.8
+  resolution: "undici-types@npm:6.19.8"
+  checksum: 10c0/078afa5990fba110f6824823ace86073b4638f1d5112ee26e790155f481f2a868cc3e0615505b6f4282bdf74a3d8caad715fd809e870c2bb0704e3ea6082f344
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add `baseUrlTemplate` to `PangeaConfig` to allow for greater control over the complete API URL. This option may be a full URL with the optional `{SERVICE_NAME}` placeholder, which will be replaced by the slug of the respective service name. This supersedes `environment` and `insecure`.